### PR TITLE
Add multi-button form support

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -36,18 +36,26 @@ jQuery(function ($) {
          * - ajax:complete - is execute when status is complete
          * - ajax:failure  - is execute in case of error
          * - ajax:after    - is execute every single time at the end of ajax call 
+         * 
+         * Optional: Accepts an event who's target will be included with the submitted data
          */
-        callRemote: function () {
+        callRemote: function (e) {
             var el      = this,
                 method  = el.attr('method') || el.attr('data-method') || 'GET',
                 url     = el.attr('action') || el.attr('href'),
                 dataType  = el.attr('data-type')  || 'script';
-
             if (url === undefined) {
                 throw "No URL specified for remote call (action or href must be present).";
             } else {
                 if (el.triggerAndReturn('ajax:before')) {
                     var data = el.is('form') ? el.serializeArray() : [];
+                    if (e && e.target) {
+                        var target = $(e.target);
+                        var name = target.attr('name');
+                        if (name) {
+                          data.push({name: name, value: target.attr('value')});
+                        }
+                    }
                     $.ajax({
                         url: url,
                         data: data,
@@ -91,8 +99,17 @@ jQuery(function ($) {
     /**
      * remote handlers
      */
+
+    //This allows a multiple button form to work properly, passing the button as a data parameter
+    $('form[data-remote] input[type=\'submit\'], form[data-remote] button').live('click', function (e) {
+        $(this).closest('form').callRemote(e);
+        e.preventDefault();
+    });
+
+    //This is the original handler. Fortunately, both will not fire, 
+    // since the event is prevented from bubbling by the click handler
     $('form[data-remote]').live('submit', function (e) {
-        $(this).callRemote();
+        $(this).callRemote(e);
         e.preventDefault();
     });
 

--- a/test/public/test/data-remote.js
+++ b/test/public/test/data-remote.js
@@ -31,6 +31,20 @@ module('data-remote', {
 			'value': 'john'
 		}));
 
+        form.append($('<input />', {
+            id: "team_submit",
+            type: "submit",
+            name: "team", 
+            value: "Team 1"
+        }));
+
+        form.append($('<button />', {
+            id: "team_button",
+            name: "team", 
+            value: "Team 2"
+        }));
+
+
     $('#fixtures').append(form);
 
 	}
@@ -90,3 +104,50 @@ test('Submitting form with data-remote attribute', function() {
     .trigger('submit');
 });
 
+test('Submitting multi-button form with data-remote attribute using html input', function() {
+  expect(5);
+  stop(App.ajax_timeout);
+
+  $('form[data-remote]')
+    .live('ajax:success', function(e, data, status, xhr) { 
+      App.assert_callback_invoked('ajax:success');
+
+      var request_env = $.parseJSON(data)['request_env'],
+          params = request_env['rack.request.query_hash'];
+
+      App.assert_request_path(request_env, '/update');
+      equals(params['user_name'], 'john', 'ajax arguments should have key user_name with right value');
+      equals(params['team'], 'Team 1', 'ajax arguments should have button key with right value');
+      App.assert_post_request(request_env); 
+
+    })
+ 
+  $('form[data-remote] input[type=\'submit\']#team_submit').trigger('click');
+
+  start();
+
+});
+
+test('Submitting multi-button form with data-remote attribute using html button', function() {
+  expect(5);
+  stop(App.ajax_timeout);
+
+  $('form[data-remote]')
+    .live('ajax:success', function(e, data, status, xhr) { 
+      App.assert_callback_invoked('ajax:success');
+
+      var request_env = $.parseJSON(data)['request_env'],
+          params = request_env['rack.request.query_hash'];
+
+      App.assert_request_path(request_env, '/update');
+      equals(params['user_name'], 'john', 'ajax arguments should have key user_name with right value');
+      equals(params['team'], 'Team 2', 'ajax arguments should have button key with right value');
+      App.assert_post_request(request_env); 
+
+    })
+ 
+  $('form[data-remote] button#team_button').trigger('click');
+
+  start();
+
+})


### PR DESCRIPTION
I have modified the form submission function `callRemote` to allow a button to be passed in and be submitted with the form data. I also added the a live event call that adds a 'click' event handler to each submit button in a form, passing to `callRemote` that button as an argument. The submit event has been left intact. Only one or the other should fire since the event is kept from bubbling up. I have not had time to write a test and also am not familiar with the test framework.
