### PR TITLE
use config.action_view.javascript_expansions[:defaults] instead for README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -19,16 +19,11 @@ Copy rails.js from http://github.com/rails/jquery-ujs/raw/master/src/rails.js in
   
 === Step 3 (optional)
 
-Create an initializer to switch the javascript_include_tag :defaults to use jquery instead of the default prototype helpers.
+Switch the javascript_include_tag :defaults to use jquery instead of the default prototype helpers.
 
-file config/initializers/jquery.rb
+file config/application.rb
 
-  module ActionView::Helpers::AssetTagHelper
-    remove_const :JAVASCRIPT_DEFAULT_SOURCES
-    JAVASCRIPT_DEFAULT_SOURCES = %w(jquery.js rails.js)
-
-    reset_javascript_include_default
-  end
+  config.action_view.javascript_expansions[:defaults] = %w(jquery rails application)
 
 = Testing
   


### PR DESCRIPTION
the README still tells people to create an intialiazer file. we should instead actually use config.action_view.javascript_expansions[:defaults] in config/application.rb.
