### PR TITLE
Fix for Issue 8 - IE / jQuery 1.4.2 submit event bubbling bug

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -73,10 +73,10 @@ jQuery(function ($) {
     /**
      * remote handlers
      */
-    $('form[data-remote]').live('submit', function (e) {
-        $(this).callRemote();
-        e.preventDefault();
-    });
+		$('form[data-remote]', $.browser.msie ? $('body')[0] : $(document)).live('submit', function(e) { 
+			  $(this).callRemote();
+			  e.preventDefault(); 
+		});
 
     $('a[data-remote],input[data-remote]').live('click', function (e) {
         $(this).callRemote();


### PR DESCRIPTION
We ran into this same issue and worked around it by binding to the <body> element rather than document on IE. Seems to solve the issue in a clean way.

Matt
