### PR TITLE
jQuery 1.4.4

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -8,6 +8,7 @@ Unobtrusive jQuery with Rails 3
 * 1.4.1
 * 1.4.2
 * 1.4.3
+* 1.4.4
 
 == Automated Installation
 
@@ -30,7 +31,7 @@ Run this command:
 
 Download jQuery from http://docs.jquery.com/Downloading_jQuery and put the file in public/javascripts. For example, the file might look like:
 
-  public/javascripts/jquery-1.4.3.min.js
+  public/javascripts/jquery-1.4.4.min.js
 
 === Step 2
 
@@ -55,4 +56,4 @@ Switch the <tt>javascript_include_tag :defaults</tt> to use jquery instead of th
 
 Visit http://localhost:4567 and all the tests should pass. 
 
-At the top of the page you will see links to jQuery 1.4.1, 1.4.2 and 1.4.3 . By clicking on those links you will be executing the tests against the clicked version of jquery. By default test uses jQuery 1.4.3 .
+At the top of the page you will see links to jQuery 1.4.1, 1.4.2, 1.4.3, and 1.4.4 . By clicking on those links you will be executing the tests against the clicked version of jquery. By default test uses jQuery 1.4.4.

--- a/test/server.rb
+++ b/test/server.rb
@@ -15,7 +15,7 @@ end
 
 get '/' do
   FileUtils.cp(source_file, dest_file)
-  params[:version] ||= '1.4.3'
+  params[:version] ||= '1.4.4'
   erb :index
 end
 

--- a/test/views/index.erb
+++ b/test/views/index.erb
@@ -26,6 +26,7 @@
       <%= jquery_link '1.4.1' %>
       <%= jquery_link '1.4.2' %>
       <%= jquery_link '1.4.3' %>
+      <%= jquery_link '1.4.4' %>
     </h1>
     <h2 id="qunit-banner"></h2>
     <h2 id="qunit-userAgent"></h2>


### PR DESCRIPTION
jQuery 1.4.4 was just released, so I thought it would be good if it were noted in the README that 1.4.4 is supported/recommended etc.

I ran all of the tests and they all passed on 1.4.4.

I'm not sure if there were plans to take out some of the if/else stuff in rails.js when future versions of jQuery get released, but I'll leave that up for you.
