### PR TITLE
Rails namespace

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -77,7 +77,7 @@ jQuery(function ($) {
      *  confirmation handler
      */
 
-    $('body').delegate('a[data-confirm], button[data-confirm], input[data-confirm]', 'click', function () {
+    $('body').delegate('a[data-confirm], button[data-confirm], input[data-confirm]', 'click.rails', function () {
         var el = $(this);
         if (el.triggerAndReturn('confirm')) {
             if (!confirm(el.attr('data-confirm'))) {
@@ -91,17 +91,17 @@ jQuery(function ($) {
     /**
      * remote handlers
      */
-    $('form[data-remote]').live('submit', function (e) {
+    $('form[data-remote]').live('submit.rails', function (e) {
         $(this).callRemote();
         e.preventDefault();
     });
 
-    $('a[data-remote],input[data-remote]').live('click', function (e) {
+    $('a[data-remote],input[data-remote]').live('click.rails', function (e) {
         $(this).callRemote();
         e.preventDefault();
     });
 
-    $('a[data-method]:not([data-remote])').live('click', function (e){
+    $('a[data-method]:not([data-remote])').live('click.rails', function (e){
         var link = $(this),
             href = link.attr('href'),
             method = link.attr('data-method'),
@@ -136,10 +136,10 @@ jQuery(function ($) {
         });
     };
 
-    $(disable_with_form_remote_selector).live('ajax:before', disable_with_input_function);
-    $(disable_with_form_not_remote_selector).live('submit', disable_with_input_function);
+    $(disable_with_form_remote_selector).live('ajax:before.rails', disable_with_input_function);
+    $(disable_with_form_not_remote_selector).live('submit.rails', disable_with_input_function);
 
-    $(disable_with_form_remote_selector).live('ajax:complete', function () {
+    $(disable_with_form_remote_selector).live('ajax:complete.rails', function () {
         $(this).find(disable_with_input_selector).each(function () {
             var input = $(this);
             input.removeAttr('disabled')


### PR DESCRIPTION
Looks like we're finally ready to pull this in :-) This was a pull request a couple times before [1] [2]. As requested, I've re-added the 'rails' event namespacing to the latest from master, which now supports jQuery 1.4.3 and 1.4.4.

[1] https://github.com/rails/jquery-ujs/pull/29
[2] https://github.com/rails/jquery-ujs/pull/37
