### PR TITLE
Prevent double clicking

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -108,6 +108,12 @@ jQuery(function ($) {
             form = $('<form method="post" action="'+href+'"></form>'),
             metadata_input = '<input name="_method" value="'+method+'" type="hidden" />';
 
+        if (link.data('rails.submiting')) {
+            e.preventDefault();
+            return;
+        }
+        link.data('rails.submiting', true);
+
         if (csrf_param !== undefined && csrf_token !== undefined) {
             metadata_input += '<input name="'+csrf_param+'" value="'+csrf_token+'" type="hidden" />';
         }

--- a/test/public/test/data-method-iframe.js
+++ b/test/public/test/data-method-iframe.js
@@ -13,11 +13,14 @@ module('data-remote-iframe', {
   }
 });
 
-test('clicking on a link with data-method attribute', function() {
+test('double clicking on a link with data-method attribute', function() {
   expect(0);
   stop();
 
   $('a[data-method]')
+    .trigger('click');
+  
+  $('a[data-method]').attr('href', App.url('update'))
     .trigger('click');
 
     App.timeout();


### PR DESCRIPTION
Some very strange users make double click on links. Or they click, but page is loading and didn’t change, so they click again. Because on every click new `<form>` will be created, double clicking create two requests. It’s very bad, because `data-method` used in POST/PUT/DELETE modification requests, for example user will be pay twice.

In this patch block clicking on `a[data-method]`, while it’s already submiting.
