### PR TITLE
include additional params into data on submit

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -47,7 +47,17 @@ jQuery(function ($) {
                 throw "No URL specified for remote call (action or href must be present).";
             } else {
                 if (el.triggerAndReturn('ajax:before')) {
-                    var data = el.is('form') ? el.serializeArray() : [];
+                    var data = [];
+                    if (el.is('form')) {
+                      data = el.serializeArray();
+                      var ext_data = jQuery.data(el[0]);
+                      for (key in ext_data) {
+                        var matches = key.match(/^rails:data:(.*)/);
+                        if (matches) {
+                          data.push({ name: matches[1], value: ext_data[key]});
+                        }
+                      }
+                    }
                     $.ajax({
                         url: url,
                         data: data,
@@ -95,6 +105,10 @@ jQuery(function ($) {
     $('form[data-remote]').live('submit.rails', function (e) {
         $(this).callRemote();
         e.preventDefault();
+    });
+
+    $('form[data-remote] input[type=submit]').live('click.rails', function (e) {
+        jQuery.data($(this).parents('form')[0], 'rails:data:submit', e.target.name);
     });
 
     $('a[data-remote],input[data-remote]').live('click.rails', function (e) {


### PR DESCRIPTION
I need to be able to include additional variables into the data object on submit. 

This patch uses the jquery .data() feature to enable this. To include an additional param you just do jQuery.data(form_element, 'rails:data:your_variable', 'your-value'); or you can add a param 'data-rails:data:<your-variable-key>=<your-value> on the form tag, since that is how the .data(el) function works in jquery. 

This patch also fixes the bug that the submit button name is not included in the data object. The fix uses the above feature.
