### PR TITLE
Fix of Firefox specific bug.

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -52,7 +52,7 @@ jQuery(function ($) {
                         dataType: dataType,
                         type: method.toUpperCase(),
                         beforeSend: function (xhr) {
-                            xhr.setRequestHeader("Accept", "text/javascript");
+                            xhr.setRequestHeader("Accept", "*/*");
                             if ($this.triggerHandler('ajax:beforeSend') === false) {
                               return false;
                             }


### PR DESCRIPTION
Rails returns "406 Not Acceptable" when the response type in an ajax call is different from "text/javascript" (e.g. json). This is because the Accept header is overwritten in Firefox when setting "Accept" to "text/javascript" as the existing code does before invoking the ajax request. (This bug does not appear in other browsers because they prepend "_/_" to the Accept header field.)
I've fixed it by setting the Accept field to "_/_".
