### PR TITLE
changing beforeSend to be more accurate according to the jquery spec

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -41,21 +41,21 @@ jQuery(function ($) {
             if (url === undefined) {
                 throw "No URL specified for remote call (action or href must be present).";
             } else {
-                    var $this = $(this), data = el.is('form') ? el.serializeArray() : [];
+                    var data = el.is('form') ? el.serializeArray() : [];
 
                     $.ajax({
                         url: url,
                         data: data,
                         dataType: dataType,
                         type: method.toUpperCase(),
-                        beforeSend: function (xhr) {
-                            if ($this.triggerHandler('ajax:beforeSend') === false) {
+                        beforeSend: function (xhr, settings) {
+                            if (el.triggerHandler('ajax:beforeSend') === false) {
                               return false;
                             }
                            // if user has used jQuery.ajaxSetup then call beforeSend callback
                             var beforeSendGlobalCallback =  $.ajaxSettings && $.ajaxSettings.beforeSend;
                             if (beforeSendGlobalCallback !== undefined) {
-                                beforeSendGlobalCallback(xhr);
+                                return beforeSendGlobalCallback.call(this, xhr, settings, el);
                             }
                         },
                         success: function (data, status, xhr) {

--- a/test/public/test/call-remote-callbacks.js
+++ b/test/public/test/call-remote-callbacks.js
@@ -44,6 +44,24 @@ test('ajax:beforeSend returns false do not proceed', function() {
   App.short_timeout();
 });
 
+test('jQuery.ajaxSettings beforeSend returns false do not proceed', function() {
+  expect(0);
+  stop();
+  $.ajaxSetup({
+    beforeSend : function(xhr) {
+      return false;
+    }
+  })
+  $('form')
+    .bind('ajax:complete', function(){
+      ok(false, 'ajax call should not have been made since ajax:beforeSend callback returns false');
+    });
+
+  $('form[data-remote]').trigger('submit');
+
+  App.short_timeout();
+});
+
 test('beforeSend, success and complete callbacks should be called', function() {
 	expect(3);
   stop(App.ajax_timeout);


### PR DESCRIPTION
We are working on a part of our website and we needed to tie into the jquery global beforeSend function.  While trying to use this method we were trying to cancel the ajax request in certain scenarios.

If you put in
$('a').live('ajax:beforeSend', function(event, xhr) { 
  return false;
});

Then the ajax request is not sent.  With this change I also noticed that on line 44 $this was being assigned to $(this), but the variable el is already assigned to the equivalent of $(this), so I removed that variable.

I've also changed the jquery global beforeSend call back to be called with the same parameters that are used if you call before send without the beforeSend in rails.js

return beforeSendGlobalCallback.call(this, xhr, settings, el);
The first argument(this) ensures that the global beforeSend is called within the same context as it would have been called in if the beforeSend is not in the rails.js file.  The second argument was already being passed along.  The third argument is specified in the jquery docs as settings, just passing that along as is.
And last but not least, I'm passing the element that made the ajax call as the 4th argument.

This commit is just making the beforeSend method conform to the way the global beforeSend works, except for passing the element as the forth argument.  I didn't see any tests around what arguments are passed to the beforeSend method but I did add a test to confirm returning false from the global beforeSend works as expected.

I would also like to make it so that the complete(and possibly error) callback will call the global callback, but I didn't want to make too many changes per pull request.

What do you guys think about this pull request?  Would you be willing to accept a pull request allowing complete and or error to call the global callback as well?
