### PR TITLE
Prefer JS format for AJAX requests, but accept anything by default

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -34,7 +34,10 @@
 		$.ajax({
 			url: url, type: method, data: data, dataType: dataType,
 			// stopping the "ajax:beforeSend" event will cancel the ajax request
-			beforeSend: function(xhr) {
+			beforeSend: function(xhr, settings) {
+				if ( settings.dataType == undefined ) {
+					xhr.setRequestHeader("Accept", settings.accepts.script + ", */*; q=0.5");
+				}
 				return fire(element, 'ajax:beforeSend', xhr);
 			},
 			success: function(data, status, xhr) {


### PR DESCRIPTION
I'm not sure if everyone is on board for this yet, but I'll be away from my computer most of the weekend, so I thought I'd go ahead and submit this pull request just in case.

See [this Issue ticket](https://github.com/rails/jquery-ujs/issues#issue/74) for discussion.

Updated rails.js to set the Accepts header, such that it prefers JS by default, but will accept whatever the default Responder format is if format.js is not allowed for that request.
