### PR TITLE
More info in `ajax:beforeSend` and `ajax:complete` events

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -34,14 +34,14 @@
 		$.ajax({
 			url: url, type: method, data: data, dataType: dataType,
 			// stopping the "ajax:beforeSend" event will cancel the ajax request
-			beforeSend: function(xhr) {
-				return fire(element, 'ajax:beforeSend', xhr);
+			beforeSend: function(xhr, settings) {
+				return fire(element, 'ajax:beforeSend', [xhr, settings]);
 			},
 			success: function(data, status, xhr) {
 				element.trigger('ajax:success', [data, status, xhr]);
 			},
-			complete: function(xhr) {
-				element.trigger('ajax:complete', xhr);
+			complete: function(xhr, status) {
+				element.trigger('ajax:complete', [xhr, status]);
 			},
 			error: function(xhr, status, error) {
 				element.trigger('ajax:error', [xhr, status, error]);


### PR DESCRIPTION
The `ajax:beforeSend` and `ajax:complete` triggered events only pass through the `xhr` parameter. However, jQuery provides an additional parameter for each callback:

```
beforeSend ( xhr, settings )
complete ( xhr, status )
```

([see $.ajax docs](http://api.jquery.com/jQuery.ajax/))

The `ajax:success` and `ajax:error` events pass through all the parameters to the triggered events that are made available by jQuery, so I thought the other two events should as well.
