### PR TITLE
Required input fields

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -23,7 +23,21 @@
 			url = element.attr('action');
 			data = element.serializeArray();
 			// memoized value from clicked submit button
-			var button = element.data('ujs:submit-button');
+			var button = element.data('ujs:submit-button'),
+			    requiredInputs = element.find('input[required]'),
+			    blankRequiredInputs = false;
+
+			$.each(requiredInputs, function(){
+				if( ! $(this).val() ) {
+					blankRequiredInputs = true;
+					return false;
+				}
+			});
+			if (blankRequiredInputs) {
+				element.bind('ajax:beforeSend.required', false);
+			} else {
+				element.unbind('ajax:beforeSend.required');
+			}
 			if (button) {
 				data.push(button);
 				element.data('ujs:submit-button', null);

--- a/test/public/test/call-remote-callbacks.js
+++ b/test/public/test/call-remote-callbacks.js
@@ -33,6 +33,23 @@ asyncTest('stopping the "ajax:beforeSend" event aborts the request', 1, function
   setTimeout(function(){ start() }, 200);
 });
 
+asyncTest('blank required form input field should abort request', 2, function() {
+	var form = $('form[data-remote]'), input = form.append($('<input type="text" name="user_name" required="required">')).find('input[required]');
+
+	equal(input.val(), '', 'input field should be blank');
+	
+	form.unbind('ajax:complete').bind('ajax:complete', function() {
+		ok(false, 'ajax:complete should not run');
+	}).trigger('submit');
+
+	input.val('tyler durden');
+	form.unbind('ajax:complete').bind('ajax:complete', function(){
+		ok(true, 'ajax:complete should now run');
+	}).trigger('submit');
+	
+	setTimeout(function(){ start() }, 200)
+});
+
 asyncTest('"ajax:beforeSend" can be observed and stopped with event delegation', 1, function() {
   $('form[data-remote]').live('ajax:beforeSend', function() {
     ok(true, 'ajax:beforeSend observed with event delegation');


### PR DESCRIPTION
Fixed issue described in this issue: [Do not disable submit button when required input in not filled in](https://github.com/rails/jquery-ujs/issues#issue/78).

Added check to remote forms to abort ajax request if there are any required input fields in the form that are blank. This should hopefully fix the problem with the disable issue in Opera as well, since forms don't get disabled when the ajax request is aborted.

Included tests for new functionality as well, though you may want to check my handy-work; I'm not at all experienced with QUnit or the asyncTest method. I kinda just read through a bunch of mislav's other tests to get a general feel for it.

Also, I'm not sure if we should add some sort of console logging or something when an ajax request gets aborted for this reason, as we wouldn't want developers pulling their hair out trying to figure out why a request is not happening, just because they forgot they made a form field required.
