### PR TITLE
Fire event 'confirmed' after user confirmation

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -91,7 +91,7 @@
 
 	function allowAction(element) {
 		var message = element.attr('data-confirm');
-		return !message || (fire(element, 'confirm') && confirm(message));
+		return !message || (fire(element, 'confirm') && confirm(message) && fire(element, 'confirmed'));
 	}
 
 	function requiredValuesMissing(form) {


### PR DESCRIPTION
Okay, it's nice to have the event `confirm`, so we can customize the way confirmations are done. But we still need a event that runs _after_ the confirmation, so we can perform some action that depends of it, hence the `confirmed` event. Unfortunately, I don't know how to make tests for this (I've never played with QUnit before), so you'll have to do it =). I also think there should be a test for the `confirm` event.
And thank you all for this awesome code.
