### PR TITLE
CSRF Protection Bypass in Ruby on Rails

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -36,6 +36,9 @@
 
 		$.ajax({
 			url: url, type: method || 'GET', data: data, dataType: dataType,
+			headers: {
+				"X-CSRF-Token": $("meta[name='csrf-token']").attr('content')
+			},
 			// stopping the "ajax:beforeSend" event will cancel the ajax request
 			beforeSend: function(xhr, settings) {
 				if (settings.dataType === undefined) {

--- a/test/public/test/call-remote.js
+++ b/test/public/test/call-remote.js
@@ -67,6 +67,19 @@ asyncTest('prefer JS, but accept any format', 1, function() {
   });
 });
 
+asyncTest('passes in csrf token', 1, function(){
+  build_form({ method: 'post', action: '/header' })
+
+  $("form").append($("<input>").attr("name", "key").val("X-CSRF-Token"));
+  $('#qunit-fixture')
+    .append('<meta name="csrf-param" content="authenticity_token"/>')
+    .append('<meta name="csrf-token" content="cf50faa3fe97702ca1ae"/>');
+
+  submit(function(e, data, status, xhr){
+    equal(data, $('meta[name=csrf-token]').attr('content'));
+  })
+})
+
 asyncTest('accept application/json if "data-type" is json', 1, function() {
   build_form({ method: 'post', 'data-type': 'json' });
 

--- a/test/server.rb
+++ b/test/server.rb
@@ -56,3 +56,9 @@ end
 get '/error' do
   status 403
 end
+
+post '/header' do
+  status 200
+  header_key = "HTTP_#{params[:key].upcase.gsub("-", "_")}"
+  env[header_key].to_s
+end


### PR DESCRIPTION
http://weblog.rubyonrails.org/2011/2/8/csrf-protection-bypass-in-ruby-on-rails

Last Rails release seems to break jquery-ujs ajax calls - an application’s javascript must be changed to send the token with Ajax requests.

I've noticed a [pull request](https://github.com/rails/jquery-ujs/pull/95), fixing this problem, but it's huge and clumsy. Take a look at this one - also fixes the problem with minimal efforts. 
