### PR TITLE
Allow BUTTON elements to use data-disable-with

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -94,18 +94,26 @@
 	}
 
 	function disableFormElements(form) {
-		form.find('input[data-disable-with]').each(function() {
+		form.find('input[data-disable-with], button[data-disable-with]').each(function() {
 			var input = $(this);
-			input.data('ujs:enable-with', input.val())
-				.val(input.attr('data-disable-with'))
-				.attr('disabled', 'disabled');
+			if (input.is('input'))
+				input.data('ujs:enable-with', input.val())
+					.val(input.attr('data-disable-with'));
+			else
+				input.data('ujs:enable-with', input.text())
+					.text(input.attr('data-disable-with'));
+			input.attr('disabled', 'disabled');
 		});
 	}
 
 	function enableFormElements(form) {
-		form.find('input[data-disable-with]').each(function() {
+		form.find('input[data-disable-with], button[data-disable-with]').each(function() {
 			var input = $(this);
-			input.val(input.data('ujs:enable-with')).removeAttr('disabled');
+			if (input.is('input'))
+				input.val(input.data('ujs:enable-with'));
+			else
+				input.text(input.data('ujs:enable-with'));
+			input.removeAttr('disabled');
 		});
 	}
 

--- a/test/public/test/data-disable.js
+++ b/test/public/test/data-disable.js
@@ -10,11 +10,20 @@ module('data-disable', {
 
     $('#qunit-fixture').append($('<form />', {
       action: '/echo',
-      method: 'post'
+      method: 'post',
+      id: 'submit-tag'
     }))
       .find('form:last')
       // WEEIRDD: the form won't submit to an iframe if the button is name="submit" (??!)
       .append($('<input type="submit" data-disable-with="submitting ..." name="submit2" value="Submit" />'));
+
+    $('#qunit-fixture').append($('<form />', {
+      action: '/echo',
+      method: 'post',
+      id: 'submit-button'
+    }))
+      .find('form:last')
+      .append($('<button data-disable-with="submitting ..." name="submit2">Submit</button>'));
   }
 });
 
@@ -41,7 +50,7 @@ asyncTest('form input field with "data-disable-with" attribute', 7, function() {
 });
 
 asyncTest('form submit button with "data-disable-with" attribute', 6, function(){
-  var form = $('form:not([data-remote])'), input = form.find('input[type=submit]');
+  var form = $('#submit-tag'), input = form.find('input[type=submit]');
 
   ok(!input.is(':disabled'), 'input field should not be disabled');
   equal(input.val(), 'Submit', 'input field should have value given to it');
@@ -49,6 +58,30 @@ asyncTest('form submit button with "data-disable-with" attribute', 6, function()
   function checkDisabledState() {
     ok(input.is(':disabled'), 'input field should be disabled');
     equal(input.val(), 'submitting ...');
+  }
+
+  // WEEIRDD: attaching this handler makes the test work in IE7
+  form.bind('iframe:loading', function(e, form) {});
+
+  form.bind('iframe:loaded', function(e, data) {
+    setTimeout(function() {
+      checkDisabledState();
+      start();
+    }, 30);
+  }).trigger('submit');
+
+  setTimeout(checkDisabledState, 30);
+});
+
+asyncTest('form submit button as a button with "data-disable-with" attribute', 6, function(){
+  var form = $('#submit-button'), input = form.find('button');
+
+  ok(!input.is(':disabled'), 'input field should not be disabled');
+  equal(input.text(), 'Submit', 'input field should have value given to it');
+
+  function checkDisabledState() {
+    ok(input.is(':disabled'), 'input field should be disabled');
+    equal(input.text(), 'submitting ...');
   }
 
   // WEEIRDD: attaching this handler makes the test work in IE7


### PR DESCRIPTION
As HTML `BUTTON` tags are generally the preferred implementation of submit elements for designers (due to CSS styling supports and cross-browser presentation consistency), and the Rails form helper supports the button call, it makes sense for `data-disable-with` to work with `BUTTON` elements.

The current release restricts the jQuery element search strictly to `INPUT` elements.  This patch widens the search to include `BUTTON` elements, as well.. although you'll notice that it now introduces a conditional, since inputs respond to `val()` while buttons respond to `text()`.

Tests have been added to cover the new feature as described and all regression tests remain green.
