### PR TITLE
Fixed ajax request on IE6/IE7.

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -7,21 +7,18 @@
 
 (function($) {
 	// Make sure that every Ajax request sends the CSRF token
-	var getCSRFToken = (function(){
-		var token = null;
-		return function(){
-			return token || (token = $('meta[name="csrf-token"]').attr('content'));
-		};
-	})();
+	function CSRFProtection(xhr) {
+		var token = $('meta[name="csrf-token"]').attr('content');
+		if (token) xhr.setRequestHeader('X-CSRF-Token', token);
+	}
 
 	if ('ajaxPrefilter' in $) {
-		$.ajaxPrefilter(function(options) {
-			options.headers = options.headers || {};
-			options.headers['X-CSRF-Token'] = getCSRFToken();
+		$.ajaxPrefilter(function(options, originalOptions, xhr) {
+			CSRFProtection(xhr);
 		});
 	} else {
 		$(document).ajaxSend(function(e, xhr) {
-			xhr.setRequestHeader('X-CSRF-Token', getCSRFToken());
+			CSRFProtection(xhr);
 		});
 	}
 


### PR DESCRIPTION
This contains several things:
- on IE6/IE7 the previous usage of open.apply(this, arguments) throws errors on IE6/IE7.
- used "feature detect" instead of depending on jQuery 1.5 (jQuery 1.5.1 would have broken the old version).
- caches the token variable so we don't touch the DOM on every ajax request.
