### PR TITLE
Indented elements (Haml) cause spaces before non-first line of confirmation message

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -99,6 +99,10 @@
 
 	function allowAction(element) {
 		var message = element.attr('data-confirm');
+		// Account for Haml indenting other lines than the first one.
+		if (message) {
+			message = message.replace(/\n */g, "\n");
+		}
 		return !message || (fire(element, 'confirm') && confirm(message));
 	}
 


### PR DESCRIPTION
I tend to specify confirmation messages in two "paragraphs", with the second one providing details.

If I do something like

```
= button_to("Foo", "/url", :confirm => "Really?\n\nThis cannot be undone.")
```

in Haml, the resulting HTML will be indented, so `attr('data-confirm')` will really be something like

```
"Really?\n    \n    This cannot be undone."
```

At least in Chrome on OS X, the extra spaces show in the dialog and look bad.

In non-UJS Rails, this worked as expected.

I tried with ERB and that worked as expected. I tried using `find_and_preserve` in Haml but wasn't able to get rid of the extra whitespace that way. And either way, since a lot of people use Haml with Rails, it probably makes sense to make it work without extra effort there.

The attached fix gets rid of the extra whitespace before popping up the confirmation. Another solution could be to make Rails store literal `\n` characters and then replace those on the JavaScript end.
