### PR TITLE
Ajax:success callback parameters order

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -51,8 +51,8 @@
 				}
 				return fire(element, 'ajax:beforeSend', [xhr, settings]);
 			},
-			success: function(data, status, xhr) {
-				element.trigger('ajax:success', [data, status, xhr]);
+			success: function(xhr, data, status) {
+				element.trigger('ajax:success', [xhr, data, status]);
 			},
 			complete: function(xhr, status) {
 				element.trigger('ajax:complete', [xhr, status]);


### PR DESCRIPTION
Hi, I think Ajax:success parameters are not in the right order. In order to make it work, I have to use the following jquery callback code. So the order is xhr, data, status, and not data, status, xhr.

$("#request").bind("ajax:success", function(xhr, data, status) {
    $("#response").html(data);
});
