### PR TITLE
Add correct Content-Type when ajax:beforeSend sets data.

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -49,7 +49,15 @@
 				if (settings.dataType === undefined) {
 					xhr.setRequestHeader('accept', '*/*;q=0.5, ' + settings.accepts.script);
 				}
-				return fire(element, 'ajax:beforeSend', [xhr, settings]);
+
+				if( fire(element, 'ajax:beforeSend', [xhr, settings]) === false ) {
+					return false;
+				}
+
+				// Set the correct content-type if data was provided in the beforeSend event
+				if ( settings.data && settings.hasContent && settings.contentType !== false ) {
+					xhr.setRequestHeader("Content-Type", settings.contentType);
+				}
 			},
 			success: function(data, status, xhr) {
 				element.trigger('ajax:success', [data, status, xhr]);


### PR DESCRIPTION
This modification allows to unobtrusively add data to remote POST or PUT tags that aren't forms via the ajax:beforeSend event. Normally when data is provided the Content-Type is set internally by jQuery, but this happens before the beforeSend callback has been handled (line 6707, jQuery v1.5.1). 

Example:

```
link_to("Flag", foo_path, :remote => true, :method => :put, :class => :do_foo)

$( function() {
    $(".do_foo").bind("ajax:beforeSend", function(event, xhr, settings) {
        settings.data = jquery.param({"foo[bar]": magic_value});
    });
});
```
