### PR TITLE
Ie cancel submit

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -155,9 +155,14 @@
 		return nonBlankExists;
 	}
 
+  function stopEverything(e) {
+    e.stopImmediatePropagation();
+    return false;
+  }
+
 	$('a[data-confirm], a[data-method], a[data-remote]').live('click.rails', function(e) {
 		var link = $(this);
-		if (!allowAction(link)) return false;
+		if (!allowAction(link)) return stopEverything(e);
 
 		if (link.data('remote') != undefined) {
 			handleRemote(link);
@@ -170,7 +175,7 @@
 
 	$('form').live('submit.rails', function(e) {
 		var form = $(this), remote = form.data('remote') != undefined;
-		if (!allowAction(form)) return false;
+		if (!allowAction(form)) return stopEverything(e);
 
 		// skip other logic when required values are missing or file upload is present
 		if (blankInputs(form, 'input[name][required]') && fire(form, 'ajax:aborted:required')) {
@@ -191,7 +196,7 @@
 
 	$('form input[type=submit], form input[type=image], form button[type=submit], form button:not([type])').live('click.rails', function() {
 		var button = $(this);
-		if (!allowAction(button)) return false;
+		if (!allowAction(button)) return stopEverything(e);
 		// register the pressed submit button
 		var name = button.attr('name'), data = name ? {name:name, value:button.val()} : null;
 		button.closest('form').data('ujs:submit-button', data);


### PR DESCRIPTION
Fixed behavior for IE, in which remote form was being submitted, even if the submit button had `data-confirm` and was cancelled. See [this comment](https://github.com/rails/jquery-ujs/issues/#issue/114/comment/854083) for cause and explanation.

I didn't add any tests because this was an IE-only bug. I'm sure I could write a failing test-case which could be observed if the test suite is run in IE, but for the most part, I just considered it a success that I implemented this fix without making any of the existing tests fail. Let me know if this is essential, and I'll figure out a test.
