### PR TITLE
Ie submit bubbles

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -160,6 +160,16 @@
     return false;
   }
 
+  function callFormSubmitBindings(form) {
+    var events = form.data('events'), continuePropagation = true;
+    if (events != undefined && events['submit'] != undefined) {
+      $.each(events['submit'], function(i, obj){
+        if (typeof obj.handler === 'function') return continuePropagation = obj.handler(obj.data);
+      })
+    }
+    return continuePropagation;
+  }
+
 	$('a[data-confirm], a[data-method], a[data-remote]').live('click.rails', function(e) {
 		var link = $(this);
 		if (!allowAction(link)) return stopEverything(e);
@@ -184,6 +194,10 @@
 		if (nonBlankInputs(form, 'input:file')) {
 			return fire(form, 'ajax:aborted:file');
 		}
+
+    // If browser does not support submit bubbling, then this live-binding will be called before direct
+    // bindings. Therefore, we should directly call any direct bindings before remotely submitting form.
+    if (!$.support.submitBubbles && callFormSubmitBindings(form) == false) return stopEverything(e)
 
 		if (remote) {
 			handleRemote(form);

--- a/test/public/test/data-remote.js
+++ b/test/public/test/data-remote.js
@@ -37,3 +37,54 @@ asyncTest('submitting form with data-remote attribute', 4, function() {
     .bind('ajax:complete', function() { start() })
     .trigger('submit');
 });
+
+asyncTest('form\'s submit bindings in browsers that don\'t support submit bubbling', 4, function() {
+  var form = $('form[data-remote]'), directBindingCalled = false;
+
+  ok(!directBindingCalled, 'nothing is called');
+
+  form
+    .append($('<input type="submit" />'))
+    .bind('submit', function(){
+      ok(true, 'binding handler is called');
+      directBindingCalled = true;
+    })
+    .bind('ajax:beforeSend', function(){
+      ok(true, 'form being submitted via ajax');
+      ok(directBindingCalled, 'binding handler already called');
+    })
+    .bind('ajax:complete', function(){
+      start();
+    });
+
+    if(!$.support.submitBubbles) {
+      // Must indrectly submit form via click to trigger jQuery's manual submit bubbling in IE
+      form.find('input[type=submit]')
+      .trigger('click');
+    } else {
+      form.trigger('submit');
+    }
+});
+
+asyncTest('returning false in form\'s submit bindings in non-submit-bubbling browsers', 1, function(){
+  var form = $('form[data-remote]');
+
+  form
+    .append($('<input type="submit" />'))
+    .bind('submit', function(){
+      ok(true, 'binding handler is called');
+      return false;
+    })
+    .bind('ajax:beforeSend', function(){
+      ok(false, 'form should not be submitted');
+    });
+
+    if (!$.support.submitBubbles) {
+      // Must indrectly submit form via click to trigger jQuery's manual submit bubbling in IE
+      form.find('input[type=submit]').trigger('click');
+    } else {
+      form.trigger('submit');
+    }
+
+    setTimeout(function(){ start(); }, 13);
+});


### PR DESCRIPTION
This corrects the problem described in [this comment](https://github.com/rails/jquery-ujs/issues/#issue/122/comment/857099).

Note that this patch depends on [this pull request](https://github.com/rails/jquery-ujs/pull/121), so make sure to merge that one first!

Also note that the 2 test cases added technically passed if the test suite was run in FF, Chrome, Safari, or IE9. They would only fail in <IE9, and now they pass. I tried overriding the `$.support.submitBubbles` jQuery flag in these 2 tests to emulate IE behavior no matter what browser they're run from, but bad things happened and I didn't feel like spending time hacking something that may cause the tests to break with future versions of jQuery.

TL;DR Merge other pull request first, and remember to occasionally run test suite in IE7.
