### PR TITLE
Don't set form to remote if data-remote is null

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -240,7 +240,7 @@
 
 	$(rails.formSubmitSelector).live('submit.rails', function(e) {
 		var form = $(this),
-			remote = form.data('remote') !== undefined,
+			remote = form.data('remote') != undefined,
 			blankRequiredInputs = rails.blankInputs(form, rails.requiredInputSelector),
 			nonBlankFileInputs = rails.nonBlankInputs(form, rails.fileInputSelector);
 


### PR DESCRIPTION
Some libraries are forcing the undefined data attributes to null. rails.js should not force a remote call if data-remote is null
