### PR TITLE
Fire event 'confirmed' after user confirmation

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -171,11 +171,16 @@
       });
     },
 
-    // If message provided in 'data-confirm' attribute, fires `confirm` event and returns result of confirm dialog.
-    // Attaching a handler to the element's `confirm` event that returns false cancels the confirm dialog.
+    /* If message provided in 'data-confirm' attribute:
+      - fires `confirm` event
+      - shows the confirm dialog
+      - fires the `confirmed` event
+     and returns true if no function stopped the chain and user chose yes; false otherwise.
+     Attaching a handler to the element's `confirm` event that returns false cancels the confirm dialog.
+    */
     allowAction: function(element) {
       var message = element.data('confirm');
-      return !message || (rails.fire(element, 'confirm') && confirm(message));
+      return !message || (rails.fire(element, 'confirm') && confirm(message) && rails.fire(element, 'confirmed'));
     },
 
     // Helper function which checks for blank inputs in a form that match the specified CSS selector


### PR DESCRIPTION
I've already submitted a [pull request on this topic](https://github.com/rails/jquery-ujs/pull/89) some time ago, but since the jquery-ujs code changed so much since then, I thought it was better to submit another.
Here's the deal: the `confirm` event runs before the confirm dialog appears, but we have no option to hook _after_ the user choose _yes_ or _no_ and `ajax:before` is not always a viable option, as Steve pointed.
Let me illustrate this with an example. Suppose you have an ordinary link and you want to prompt a confirmation to the user. Sure we can make this by ourselves, handling the `click` event and showing the `confirm` dialog. But it's better to render the message on the server using an attribute such `data-confirm`, so the message stays where it belongs (in the view templates not in javascript code) and we can use the i18n infrastructure as well. But wait, we can't use `data-confirm` because jquery-ujs will bind to it and our handler would not work. Obviously, we could use another attribute, like `data-confirmation`, but this results in an undesirable inconsistency. Bad. Why not use jquery-ujs to make this? Hence the `confirmed` event.
The ideal solution would include two events: something like `confirm:yes` and `confirm:no`, but this leads to a bunch of code and I think `confirmed` solves most cases. What do you think?
