### PR TITLE
Allow body for remote link with method POST  

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -112,7 +112,7 @@
         } else {
           method = element.data('method');
           url = element.attr('href');
-          data = element.data('body') || null; 
+          data = element.data('params') || null; 
        }
 
         rails.ajax({

--- a/test/public/test/data-remote.js
+++ b/test/public/test/data-remote.js
@@ -4,7 +4,7 @@ module('data-remote', {
       .append($('<a />', {
         href: '/echo',
         'data-remote': 'true',
-        'data-body': 'data1=value1&data2=value2',
+        'data-params': 'data1=value1&data2=value2',
         text: 'my address'
       }))
       .append($('<form />', {


### PR DESCRIPTION
Allow link_to with remote => true for method POST with request body. I needed this in my project for a link inside another form, wich I could not insert a form inside another form. Should be usefull for other people.

Example: <%= link_to "something", path, :remote => true, :method => 'post', "data-body" => "key1=val1&key2=val2" %>
