### PR TITLE
Follow up to changes in readme #161 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,10 @@ Requirements
 ------------
 
 - [jQuery 1.4.4][jquery] or later;
-- for Ruby on Rails only: `<%= csrf_meta_tag %>` in the HEAD of your HTML layout;
+- for Ruby on Rails only: `<%= csrf_meta_tags %>` in the HEAD of your HTML layout (Rails 3.1)
 - HTML5 doctype (optional).
 
 If you don't use HTML5, adding "data" attributes to your HTML4 or XHTML pages might make them fail [W3C markup validation][validator]. However, this shouldn't create any issues for web browsers or other user agents.
-
-In Ruby on Rails 3, the `csrf_meta_tag` helper generates two meta tags containing values necessary for [cross-site request forgery protection][csrf] built into Rails. If you're using Rails 2, here is how to implement that helper:
-
-    # app/helpers/application_helper.rb
-    def csrf_meta_tag
-      if protect_against_forgery?
-        out = %(<meta name="csrf-param" content="%s"/>\n)
-        out << %(<meta name="csrf-token" content="%s"/>)
-        out % [ Rack::Utils.escape_html(request_forgery_protection_token),
-                Rack::Utils.escape_html(form_authenticity_token) ]
-      end
-    end
 
 Installation
 ------------
@@ -70,6 +58,17 @@ Configure the following in your application startup file:
 
 Now the template helper `javascript_include_tag :defaults` will generate SCRIPT tags to load jQuery and rails.js.
 
+In Ruby on Rails 3.1, the `csrf_meta_tags` helper generates two meta tags containing values necessary for [cross-site request forgery protection][csrf] built into Rails. In Rails 3.0, the helper is named `csrf_meta_tag`. If you're using Rails 2, here is how to implement that helper:
+
+    # app/helpers/application_helper.rb
+    def csrf_meta_tag
+      if protect_against_forgery?
+        out = %(<meta name="csrf-param" content="%s"/>\n)
+        out << %(<meta name="csrf-token" content="%s"/>)
+        out % [ Rack::Utils.escape_html(request_forgery_protection_token),
+                Rack::Utils.escape_html(form_authenticity_token) ]
+      end
+    end
 
 [data]: http://dev.w3.org/html5/spec/elements.html#embedding-custom-non-visible-data-with-the-data-attributes "Embedding custom non-visible data with the data-* attributes"
 [wiki]: https://github.com/rails/jquery-ujs/wiki


### PR DESCRIPTION
Follow up to changes in readme #161. Moved the Rails 2 instructions to the manual install section.
