### PR TITLE
Fix for broken cross domain behaviour in jQuery >= 1.5

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -95,6 +95,7 @@
     // Submits "remote" forms and links with ajax
     handleRemote: function(element) {
       var method, url, data,
+        crossDomain = element.data('cross-domain') || false,
         dataType = element.data('type') || ($.ajaxSettings && $.ajaxSettings.dataType);
 
       if (rails.fire(element, 'ajax:before')) {
@@ -116,7 +117,7 @@
        }
 
         rails.ajax({
-          url: url, type: method || 'GET', data: data, dataType: dataType,
+          url: url, type: method || 'GET', data: data, dataType: dataType, crossDomain: crossDomain,
           // stopping the "ajax:beforeSend" event will cancel the ajax request
           beforeSend: function(xhr, settings) {
             if (settings.dataType === undefined) {
@@ -244,7 +245,7 @@
 
   // ajaxPrefilter is a jQuery 1.5 feature
   if ('ajaxPrefilter' in $) {
-    $.ajaxPrefilter(function(options, originalOptions, xhr){ rails.CSRFProtection(xhr); });
+    $.ajaxPrefilter(function(options, originalOptions, xhr){ if ( !options.crossDomain ) { rails.CSRFProtection(xhr); }});
   } else {
     $(document).ajaxSend(function(e, xhr){ rails.CSRFProtection(xhr); });
   }


### PR DESCRIPTION
Hi,

This is following up on the discussion here: https://github.com/rails/jquery-ujs/commit/a284dd706e7d76e85471ef39ab3efdf07feef374#comments

I have implemented antidis's fix. I'm sorry but I couldn't manage to write a test for it, I tried but couldn't manage to get it to work, so I deployed a simple app to illustrate the problem and show that the patched version fixes it.

If you check the app here: http://deep-autumn-373.heroku.com/home/index you will see that neither the link or the form will submit properly, as the browser will refuse to send a cross domain request with the X-CSRF-Token header. Then try the patched rails ujs (by clicking on the link at the top of the page) and it will work.

Again, apologies for the lack of a test.

Ciaran
