### PR TITLE
added remote => true to on change event in select option

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -51,6 +51,9 @@
     // Link elements bound by jquery-ujs
     linkClickSelector: 'a[data-confirm], a[data-method], a[data-remote]',
 
+		// Select elements bound by jquery-ujs
+		selectChangeSelector: 'select[data-remote]',
+
     // Form elements bound by jquery-ujs
     formSubmitSelector: 'form',
 
@@ -109,7 +112,12 @@
             data.push(button);
             element.data('ujs:submit-button', null);
           }
-        } else {
+        } else if (element.is('select')) {
+          method = element.data('method');
+          url = element.data('url');
+					data = element.serialize();
+					if (element.data('params')) data = data + "&" + element.data('params'); 
+       } else {
           method = element.data('method');
           url = element.attr('href');
           data = element.data('params') || null; 
@@ -261,6 +269,14 @@
       return false;
     }
   });
+
+	$(rails.selectChangeSelector).live('change.rails', function(e) {
+    var link = $(this);
+    if (!rails.allowAction(link)) return rails.stopEverything(e);
+
+    rails.handleRemote(link);
+    return false;
+  });	
 
   $(rails.formSubmitSelector).live('submit.rails', function(e) {
     var form = $(this),

--- a/test/public/test/data-remote.js
+++ b/test/public/test/data-remote.js
@@ -12,7 +12,16 @@ module('data-remote', {
         'data-remote': 'true',
         method: 'post'
       }))
-      .find('form').append($('<input type="text" name="user_name" value="john">'));
+      .find('form').append($('<input type="text" name="user_name" value="john">'))
+			.append($('<select />', {
+				'name': 'user_data',
+				'data-remote': 'true',
+        'data-params': 'data1=value1',
+				'data-url': '/echo'
+			}))
+			.find('select')
+			.append($('<option />', {value: 'optionValue1', text: 'option1'}))
+			.append($('<option />', {value: 'optionValue2', text: 'option2'}));
   }
 });
 
@@ -27,6 +36,20 @@ asyncTest('clicking on a link with data-remote attribute', 5, function() {
     })
     .bind('ajax:complete', function() { start() })
     .trigger('click');
+});
+
+asyncTest('changing a select option with data-remote attribute', 5, function() {
+  $('select[data-remote]')
+    .bind('ajax:success', function(e, data, status, xhr) { 
+      App.assert_callback_invoked('ajax:success');
+      App.assert_request_path(data, '/echo');
+      equal(data.params.user_data, 'optionValue2', 'ajax arguments should have key term with right value');
+			equal(data.params.data1, 'value1', 'ajax arguments should have key data1 with right value');
+      App.assert_get_request(data); 
+    })
+    .bind('ajax:complete', function() { start() })
+    .val('optionValue2')
+		.trigger('change');
 });
 
 asyncTest('submitting form with data-remote attribute', 4, function() {


### PR DESCRIPTION
In some projects i needed the remote => true support when an option is selected in a select tag. I added this feature in rails.js so you can use all the same attributes and callbacks used by links and forms.
