### PR TITLE
If form action or anchor href are empty, then get the current location

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -116,6 +116,9 @@
           data = element.data('params') || null; 
        }
 
+        //If form action or anchor href are empty, get the current location
+        url = url ? url : window.location.href;
+
         rails.ajax({
           url: url, type: method || 'GET', data: data, dataType: dataType, crossDomain: crossDomain,
           // stopping the "ajax:beforeSend" event will cancel the ajax request


### PR DESCRIPTION
When using jquery-ujs in FF 3.x while having a form with no action, the following error happens (though it works in later versions of FF and other browsers)

"Component returned failure code: 0x80070057 (NS_ERROR_ILLEGAL_VALUE) [nsIXMLHttpRequest.open]" nsresult: "0x80070057 (NS_ERROR_ILLEGAL_VALUE)"

This happens because the url is empty on rails.js.
