### PR TITLE
asynchronous call to confirm

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -90,9 +90,9 @@
       var res =  confirm(message);
       var answer = $.Deferred();
       if (res) {
-        res.resolve();
+        answer.resolve();
       } else {
-        res.reject();
+        answer.reject();
       };
       return answer.promise();
     },
@@ -276,14 +276,13 @@
 
   $(rails.linkClickSelector).live('click.rails', function(e) {
     var link = $(this);
+    e.preventDefault();
     rails.allowAction(link).then(
       function() {
         if (link.data('remote') !== undefined) {
           rails.handleRemote(link);
-          e.preventDefault();
         } else if (link.data('method')) {
           rails.handleMethod(link);
-          e.preventDefault();
         }
       }, 
       function() {
@@ -293,10 +292,10 @@
 
   $(rails.selectChangeSelector).live('change.rails', function(e) {
     var link = $(this);
+    e.preventDefault();
     rails.allowAction(link).then(
       function() {
         rails.handleRemote(link);
-        e.preventDefault();
       },
       function() {
         rails.stopEverything(e);
@@ -308,6 +307,8 @@
       remote = form.data('remote') !== undefined,
       blankRequiredInputs = rails.blankInputs(form, rails.requiredInputSelector),
       nonBlankFileInputs = rails.nonBlankInputs(form, rails.fileInputSelector);
+
+    e.preventDefault();
 
     rails.allowAction(form).then(
       function() {
@@ -326,7 +327,6 @@
          if (!$.support.submitBubbles && rails.callFormSubmitBindings(form) === false) return rails.stopEverything(e);
 
            rails.handleRemote(form);
-           e.preventDefault();
          } else {
            // slight timeout so that the submit button gets properly serialized
            setTimeout(function(){ rails.disableFormElements(form); }, 13);
@@ -339,6 +339,7 @@
 
   $(rails.formInputClickSelector).live('click.rails', function(event) {
     var button = $(this);
+    e.preventDefault();
 
     rails.allowAction(button).then(
        function() {
@@ -348,6 +349,7 @@
              data = name ? {name:name, value:button.val()} : null;
 
          button.closest('form').data('ujs:submit-button', data);
+         //TODO: submit the form
        },
        function() {
          rails.stopEverything(event);


### PR DESCRIPTION
Although it is possible to override the default confirm method, it doesn't make much sense, because the built-in window.confirm blocks the execution of code and waits for the user input. If we want to replace the default confirm with something else, for example jquery ui dialog or apprise, it would not work, because the modal box method returns immediately, and the result is returned via callback. And there is no way as far as I know to block the execution of script until the user chooses for "yes" or "no". I've made a proof-of-concept for asynchronous confirm, which uses Deferrar (jquery 1.5) Instead of returning true or false the confirm method returns a promise, so allowAction returns promise as well. In current implementation the confirm:complete has a different semantics, it gets a promise object instead of true or false, but this could be fixed. Under jquery 1.6.2 all test are passed except the two which tests confirm:complete. So the isn't ready to be included, but I would like to know if you are interested in my solution. Then I would finish it.
