### PR TITLE
Fix call-remote test when current location have no questionmark

### DIFF
--- a/test/public/test/call-remote.js
+++ b/test/public/test/call-remote.js
@@ -96,9 +96,11 @@ asyncTest('allow empty form "action"', 1, function() {
         currentLocation.href = "";
         currentLocation = currentLocation.href;
       }
+      currentLocation = currentLocation.replace(/\?$/, '');
 
       // Actual location (strip out settings.data that jQuery serializes and appends)
       ajaxLocation = settings.url.replace(settings.data,"").replace(/&$/, "");
+      ajaxLocation = ajaxLocation.replace(/\?$/, '');
       equal(ajaxLocation.match(/^(.*)/)[1], currentLocation, 'URL should be current page by default');
 
       // Prevent the request from actually getting sent to the current page and


### PR DESCRIPTION
Fixes test when we open test suite using location without questionmark.
