### PR TITLE
Passed along any original 'target' attribute to the generated form tag in handleMethod()

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -159,9 +159,10 @@
     handleMethod: function(link) {
       var href = link.attr('href'),
         method = link.data('method'),
+        target = link.attr('target') || "",  // to pass along any original 'target' attribute to the form tag
         csrf_token = $('meta[name=csrf-token]').attr('content'),
         csrf_param = $('meta[name=csrf-param]').attr('content'),
-        form = $('<form method="post" action="' + href + '"></form>'),
+        form = $('<form method="post" action="' + href + '" target="' + target + '"></form>'),
         metadata_input = '<input name="_method" value="' + method + '" type="hidden" />';
 
       if (csrf_param !== undefined && csrf_token !== undefined) {


### PR DESCRIPTION
Passed along any original 'target' attribute to the generated form tag in handleMethod().  Fixes https://github.com/rails/rails/issues/2885 for jquery-ujs.

I don't seem to be able to write a unit test for this however with the current code in the test harness. The 'target' attribute on the generated form tag is overwritten in test/settings.js when the form is submitted, so there seems to be no way to confirm the expected behavior.
