### PR TITLE
Use $.fn.prop instead of $.fn.attr for disabling/re-enabling form element

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -178,26 +178,26 @@
     /* Disables form elements:
       - Caches element value in 'ujs:enable-with' data store
       - Replaces element text with value of 'data-disable-with' attribute
-      - Adds disabled=disabled attribute
+      - Sets disabled property to true
     */
     disableFormElements: function(form) {
       form.find(rails.disableSelector).each(function() {
         var element = $(this), method = element.is('button') ? 'html' : 'val';
         element.data('ujs:enable-with', element[method]());
         element[method](element.data('disable-with'));
-        element.attr('disabled', 'disabled');
+        element.prop('disabled', true);
       });
     },
 
     /* Re-enables disabled form elements:
       - Replaces element text with cached value from 'ujs:enable-with' data store (created in `disableFormElements`)
-      - Removes disabled attribute
+      - Sets disabled property to false
     */
     enableFormElements: function(form) {
       form.find(rails.enableSelector).each(function() {
         var element = $(this), method = element.is('button') ? 'html' : 'val';
         if (element.data('ujs:enable-with')) element[method](element.data('ujs:enable-with'));
-        element.removeAttr('disabled');
+        element.prop('disabled', false);
       });
     },
 


### PR DESCRIPTION
Since UJS requires jQuery 1.6+ now, it should use the new $.fn.prop convention for disabling elements.
