### PR TITLE
Failing test case for ajax:beforeSend on a nested link

### DIFF
--- a/test/public/test/data-remote.js
+++ b/test/public/test/data-remote.js
@@ -30,6 +30,18 @@ asyncTest('clicking on a link with data-remote attribute', 5, function() {
     .trigger('click');
 });
 
+test('triggering ajax:beforeSend on a link with data-remote attribute nested inside a form should not trigger ajax:beforeSend on that form', function() {
+  var form = $('<form />')
+    .append('<a />', {
+      href: '/echo',
+      'data-remote': 'true'
+    })
+    .bind('ajax:beforeSend', function() {
+      ok(false, 'this event should never trigger');
+    })
+    .find('a').trigger('ajax:beforeSend');
+});
+
 asyncTest('changing a select option with data-remote attribute', 5, function() {
   $('form')
     .append(


### PR DESCRIPTION
When a data-remote link is nested inside a form when the ajax:beforeSend
event is triggered on that link it is also triggering the
ajax:beforeSend event on the parent form.

I'm sorry I don't know how to fix this as I gladly would but I thought having the failing
test case would go a long way to getting this fixed. (or at the very least explained)

If the answer is 'links should not be nested inside a form' normally I would agree. However,
I also do not think that when a targeted element's triggered that it should also be triggering another element's event. This feels wrong.
