### PR TITLE
Allow BUTTON elements to use "data-remote"

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -52,7 +52,7 @@
     linkClickSelector: 'a[data-confirm], a[data-method], a[data-remote], a[data-disable-with]',
 
 		// Select elements bound by jquery-ujs
-		inputChangeSelector: 'select[data-remote], input[data-remote], textarea[data-remote]',
+		inputChangeSelector: 'select[data-remote], input[data-remote], textarea[data-remote], button[data-remote]',
 
     // Form elements bound by jquery-ujs
     formSubmitSelector: 'form',


### PR DESCRIPTION
Hello there, wonderful adapter. Is it possible to add : ", button[data-remote]" to the "rails.js" file ?

``` javascript
// Select elements bound by jquery-ujs
inputChangeSelector: 'select[data-remote], input[data-remote], textarea[data-remote], button[data-remote]',
```

Thanks
