### PR TITLE
Cancelling a remote link in the ajax:before event now re-enables the link

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -150,7 +150,7 @@
         // Only pass url to `ajax` options if not blank
         if (url) { options.url = url; }
 
-        rails.ajax(options);
+        return rails.ajax(options);
       } else {
         return false;
       }

--- a/test/public/test/data-disable.js
+++ b/test/public/test/data-disable.js
@@ -206,3 +206,29 @@ asyncTest('remote link with "data-disable-with" attribute disables and re-enable
       start();
     }, 30);
 });
+
+asyncTest('remote link with "data-disable-with" attribute disables and re-enables when ajax:beforeSend event is cancelled', 6, function() {
+  var link = $('a[data-disable-with]').attr('data-remote', true);
+
+  function checkEnabledLink() {
+    ok(!link.data('ujs:enable-with'), 'link should not be disabled');
+    equal(link.html(), 'Click me', 'link should have value given to it');
+  }
+  checkEnabledLink();
+
+  function checkDisabledLink() {
+    ok(link.data('ujs:enable-with'), 'link should be disabled');
+    equal(link.html(), 'clicking...');
+  }
+
+  link
+    .bind('ajax:beforeSend', function() {
+      checkDisabledLink();
+      return false;
+    })
+    .trigger('click');
+    setTimeout(function() {
+      checkEnabledLink();
+      start();
+    }, 30);
+});


### PR DESCRIPTION
Currently, cancelling a link with data-remote=true in the ajax:before event doesn't re-enable the link. We need this because our application makes heavy use of checking for particular pre-conditions before executing an AJAX action. We can't just use confirm because we don't even want a dialog to appear if the pre-conditions are met.

We ran into this issue with the ajax:beforeSend event as well, but the fix isn't quite as straightforward.

Cheers
