### PR TITLE
Adds a condition event that allows for the cancelling of various actions 

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -210,8 +210,14 @@
       Attaching a handler to the element's `confirm` event that returns a `falsy` value cancels the confirmation dialog.
       Attaching a handler to the element's `confirm:complete` event that returns a `falsy` value makes this function
       return false. The `confirm:complete` event is fired whether or not the user answered true or false to the dialog.
+      Regardless of the presence of the 'data-confirm' attribute, the condition event will be fired to allow for custom
+      logic to prevent the execution of the action.
    */
     allowAction: function(element) {
+      if (!rails.fire(element, 'condition')) {
+        return false;
+      }
+
       var message = element.data('confirm'),
           answer = false, callback;
       if (!message) { return true; }

--- a/test/public/test/data-confirm.js
+++ b/test/public/test/data-confirm.js
@@ -99,3 +99,19 @@ asyncTest('binding to confirm:complete event and returning false', 2, function()
     start();
   }, 50);
 });
+
+asyncTest('binding to condition event and returning false', 1, function() {
+  $('a[data-confirm]')
+    .bind('condition', function() {
+      App.assert_callback_invoked('condition');
+      return false;
+    })
+    .bind('confirm', function() {
+      App.assert_callback_not_invoked('confirm')
+    })
+    .trigger('click');
+
+  setTimeout(function() {
+    start();
+  }, 50);
+});


### PR DESCRIPTION
Adds a condition event that allows for the cancelling of various actions without showing a confirm dialog.

We can't rely on the 'confirm' event because it will only fire if the data-confirm attr is present and we don't always want the confirm dialog to show up.
