### PR TITLE
Prevent usage comment from appearing in uglified version

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -1,3 +1,5 @@
+(function($, undefined) {
+
 /**
  * Unobtrusive scripting adapter for jQuery
  *
@@ -43,7 +45,6 @@
  *     });
  */
 
-(function($, undefined) {
   // Shorthand to make it a little easier to call public rails functions from within rails.js
   var rails;
 


### PR DESCRIPTION
This commit simply moves the first JavaScript line above the usage comment so the comment will not get included in the compressed version of jquery_ujs produced by uglifier. By default uglifier includes the first comment of a JavaScript file assuming it's a copyright notice - this causes jquery_ujs to include that big help comment at the top of your file when you're using the Rails asset pipeline.
