### PR TITLE
Support data-params when using data-method

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -163,11 +163,21 @@
         target = link.attr('target'),
         csrf_token = $('meta[name=csrf-token]').attr('content'),
         csrf_param = $('meta[name=csrf-param]').attr('content'),
+        params = link.data('params'),
         form = $('<form method="post" action="' + href + '"></form>'),
         metadata_input = '<input name="_method" value="' + method + '" type="hidden" />';
 
       if (csrf_param !== undefined && csrf_token !== undefined) {
         metadata_input += '<input name="' + csrf_param + '" value="' + csrf_token + '" type="hidden" />';
+      }
+
+      if (params) {
+        $.each(params.split('&'), function(i, obj) {
+          var res = obj.split('='),
+            name = res[0],
+            value = decodeURIComponent(res[1]).replace(/\+/, ' ');
+          metadata_input += '<input name="' + name + '" value="' + value + '" type="hidden" />';
+        });
       }
 
       if (target) { form.attr('target', target); }

--- a/test/public/test/data-method.js
+++ b/test/public/test/data-method.js
@@ -29,7 +29,7 @@ asyncTest('link with "data-method" and CSRF', 1, function() {
   $('#qunit-fixture')
     .append('<meta name="csrf-param" content="authenticity_token"/>')
     .append('<meta name="csrf-token" content="cf50faa3fe97702ca1ae"/>');
-  
+
   submit(function(data) {
     equal(data.params.authenticity_token, 'cf50faa3fe97702ca1ae');
   });
@@ -39,6 +39,15 @@ asyncTest('link "target" should be carried over to generated form', 1, function(
   $('a[data-method]').attr('target', 'super-special-frame');
   submit(function(data) {
     equal(data.params._target, 'super-special-frame');
+  });
+});
+
+
+asyncTest('data-params should be carried over to generated form', 2, function() {
+  $('a[data-method]').attr('data-params', 'a_param=a_value&nested[param]=encoded%20value+example');
+  submit(function(data) {
+    equal(data.params.a_param, 'a_value');
+    equal(data.params.nested.param, 'encoded value example');
   });
 });
 


### PR DESCRIPTION
This allows usage of data-params that was previously only available when also using data-remote.
For example, now this will work as expected:

``` ERB
<%= link_to 'Set Paid', admin_invoice_path(invoice), method: :put, data: { params: 'paid=true' } %>
```
