### PR TITLE
ajax:error testcase was failing on Firefox 8.0

### DIFF
--- a/test/public/test/call-remote-callbacks.js
+++ b/test/public/test/call-remote-callbacks.js
@@ -253,7 +253,7 @@ asyncTest('"ajax:beforeSend", "ajax:error" and "ajax:complete" are triggered on 
     form.bind('ajax:error', function(e, xhr, status, error) {
       ok(xhr.getResponseHeader, 'first argument to "ajax:error" should be an XHR object');
       equal(status, 'error', 'second argument to ajax:error should be a status string');
-      equal(error, 'Forbidden', 'third argument to ajax:error should be an HTTP status response');
+      equal($.trim(error), 'Forbidden', 'third argument to ajax:error should be an HTTP status response');
       // Opera returns "0" for HTTP code
       equal(xhr.status, window.opera ? 0 : 403, 'status code should be 403');
     });


### PR DESCRIPTION
The browser was sending 'Forbidden ' with trailing whitespace.
