### PR TITLE
handleRemote - move crossDomain and dataType statements to read from dat...

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -101,12 +101,11 @@
 
     // Submits "remote" forms and links with ajax
     handleRemote: function(element) {
-      var method, url, data,
-        crossDomain = element.data('cross-domain') || null,
-        dataType = element.data('type') || ($.ajaxSettings && $.ajaxSettings.dataType),
-        options;
+      var method, url, data, crossDomain, dataType, options;
 
       if (rails.fire(element, 'ajax:before')) {
+        crossDomain = element.data('cross-domain') || null;
+        dataType = element.data('type') || ($.ajaxSettings && $.ajaxSettings.dataType);
 
         if (element.is('form')) {
           method = element.attr('method');

--- a/test/public/test/call-remote-callbacks.js
+++ b/test/public/test/call-remote-callbacks.js
@@ -47,6 +47,34 @@ asyncTest('modifying form fields with "ajax:before" sends modified data in reque
   });
 });
 
+asyncTest('modifying data("type") with "ajax:before" requests new dataType in request', 2, function(){
+  $('form[data-remote]').data('type','html')
+    .live('ajax:before', function() {
+      var form = $(this);
+      form.data('type','xml')
+    });
+
+  submit(function(form) {
+    form.bind('ajax:beforeSend', function(e, xhr, settings) {
+      equal(settings.dataType, 'xml', 'modified dataType should have been requested');
+    });
+  });
+});
+
+asyncTest('setting data("cross-domain",true) with "ajax:before" uses new setting in request', 2, function(){
+  $('form[data-remote]').data('cross-domain',false)
+    .live('ajax:before', function() {
+      var form = $(this);
+      form.data('cross-domain',true)
+    });
+
+  submit(function(form) {
+    form.bind('ajax:beforeSend', function(e, xhr, settings) {
+      equal(settings.crossDomain, true, 'setting modified in ajax:before should have forced cross-domain request');
+    });
+  });
+});
+
 asyncTest('stopping the "ajax:beforeSend" event aborts the request', 1, function() {
   submit(function(form) {
     form.bind('ajax:beforeSend', function() {


### PR DESCRIPTION
...a attribute after 'ajax:before' event, to give it an opportunity to change these values dynamically

Tried to change the dataType in a ajax:before event, but discovered that the dataType variable was already set before ajax:before was called.

There may be cases when you want to change the dataType of the request dynamically - based on information only available when the event fires. This change allows the new value to be used immediately. The commit just moves code to after the event is fired.
