### PR TITLE
Use jQuery.preventDefault instead of jQuery.stopImmediatePropagation.

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -248,7 +248,7 @@
     // Helper function, needed to provide consistent behavior in IE
     stopEverything: function(e) {
       $(e.target).trigger('ujs:everythingStopped');
-      e.stopImmediatePropagation();
+      e.preventDefault();
       return false;
     },
 


### PR DESCRIPTION
I ran across a bug with using the library on an iPad. With stopImmediatePropagation, even if an alert is canceled, the action is still completed. Using preventDefault corrects the problem.

All tests pass.
