### PR TITLE
Modification to allow credentials to be passed with xhr requests

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -106,10 +106,11 @@
 
     // Submits "remote" forms and links with ajax
     handleRemote: function(element) {
-      var method, url, data, crossDomain, dataType, options;
+      var method, url, data, crossDomain, withCredentials, dataType, options;
 
       if (rails.fire(element, 'ajax:before')) {
         crossDomain = element.data('cross-domain') || null;
+        withCredentials = element.data('with-credentials') || null;
         dataType = element.data('type') || ($.ajaxSettings && $.ajaxSettings.dataType);
 
         if (element.is('form')) {
@@ -134,7 +135,7 @@
         }
 
         options = {
-          type: method || 'GET', data: data, dataType: dataType, crossDomain: crossDomain,
+          type: method || 'GET', data: data, dataType: dataType,
           // stopping the "ajax:beforeSend" event will cancel the ajax request
           beforeSend: function(xhr, settings) {
             if (settings.dataType === undefined) {
@@ -150,7 +151,11 @@
           },
           error: function(xhr, status, error) {
             element.trigger('ajax:error', [xhr, status, error]);
-          }
+          },
+          xhrFields: {
+            withCredentials: withCredentials
+          },
+          crossDomain: crossDomain
         };
         // Only pass url to `ajax` options if not blank
         if (url) { options.url = url; }
@@ -274,7 +279,7 @@
       element.data('ujs:enable-with', element.html()); // store enabled state
       element.html(element.data('disable-with')); // set to disabled state
       element.bind('click.railsDisable', function(e) { // prevent further clicking
-        return rails.stopEverything(e)
+        return rails.stopEverything(e);
       });
     },
 


### PR DESCRIPTION
@JangoSteve - This change is to allow cross-domain requests with CORS (http://www.w3.org/TR/cors/) to allow the sending of cookies for cross domain authentication.  I ran into this issue when I was attempting to re-direct from a non-secure (www.yourdomain.com) login form that posts into the secure domain (secure.yourdomain.com) or any other domain and the cookies were always getting dropped on the redirect.  XHR allows this with a setting to pass cookies and CORS to explicitly allow it server side (https://developer.mozilla.org/en/http_access_control).  I wasn't sure what to do for the unit test but I tried to mimic what you did for the data-cross-domain tag because I thought it was similar.  I also cleaned up some of the lint warnings while I was in here.  Let me know if you have questions/problems.  Thanks!
