### PR TITLE
Add target node option for html async form response

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -135,6 +135,8 @@
             data.push(button);
             element.data('ujs:submit-button', null);
           }
+          // get target node selector
+          var target = element.data('target');
         } else if (element.is(rails.inputChangeSelector)) {
           method = element.data('method');
           url = element.data('url');
@@ -156,6 +158,7 @@
             return rails.fire(element, 'ajax:beforeSend', [xhr, settings]);
           },
           success: function(data, status, xhr) {
+            if (dataType == 'html' && target) { $(target).html(data); }
             element.trigger('ajax:success', [data, status, xhr]);
           },
           complete: function(xhr, status) {


### PR DESCRIPTION
so it will insert response html to target node witch gets as jquery selector from form "data-target" if "data-type" is "html"

for example:

app/views/contact_message/new

``` haml
#form_container
  = render 'form', :contact_message => @contact_message
```

app/views/contact_message/_form

``` haml
= form_for contact_message, :remote => true, :html => {:data => {:type => :html, :target => '#form_container'}} do |f|
  = f.text_field :message
  = f.submit 'Submit'
```

app/controllers/contact_message_controller.rb

``` ruby
class ContactMessageController < ApplicationController

  def new
    @contact_message = ContactMessage.new
  end

  def create
    @contact_message = ContactMessage.new(params[:contact_message])

    if @contact_message.save
      @contact_message = ContactMessage.new
      flash.now.notice = 'success'
    else
      flash.now.alert = 'some errors'
    end

    if request.xhr?
      render :partial => '/contact_message/form', :locals => {:contact_message => @contact_message}
    else
      render :new
    end
  end

end
```
