### PR TITLE
Enabling an element that has been previously enabled should have no effect

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -308,7 +308,7 @@
 
     // restore element to its original state which was disabled by 'disableElement' above
     enableElement: function(element) {
-      if (element.data('ujs:enable-with') !== undefined) {
+      if (element.data('ujs:enable-with') !== undefined && element.data('ujs:enable-with') !== false) {
         element.html(element.data('ujs:enable-with')); // set to old enabled state
         // this should be element.removeData('ujs:enable-with')
         // but, there is currently a bug in jquery which makes hyphenated data attributes not get removed

--- a/test/public/test/data-disable.js
+++ b/test/public/test/data-disable.js
@@ -165,6 +165,19 @@ asyncTest('a[data-remote][data-disable-with] disables and re-enables', 6, functi
     .trigger('click');
 });
 
+test('re-enabling an element that is already enabled has no effect', function () {
+  var link = $('a[data-disable-with]');
+
+  $.rails.disableElement(link)
+  checkDisabledState(link, 'clicking...');
+
+  $.rails.enableElement(link)
+  checkEnabledState(link, 'Click me')
+
+  $.rails.enableElement(link)
+  checkEnabledState(link, 'Click me')
+})
+
 asyncTest('a[data-remote][data-disable-with] re-enables when `ajax:before` event is cancelled', 6, function() {
   var link = $('a[data-disable-with]').attr('data-remote', true);
 


### PR DESCRIPTION
After an element is enabled, its data attribute 'ujs:enable_with' is set to false. If $.rails.enableElement is then called again it will try to enable it again, since we are checking if it is not undefined.

I've not managed to create an async test suite that would catch this bug, because it is a very complex scenario, so I went for a simple unit test that would expose the bug.

Any thoughts?
