### PR TITLE
Update deprecated form selectors (:file, :radio, etc.)

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -257,12 +257,12 @@
 
       allInputs.each(function() {
         input = $(this);
-        valueToCheck = input.is(':checkbox,:radio') ? input.is(':checked') : input.val();
+        valueToCheck = input.is('input[type=checkbox],input[type=radio]') ? input.is(':checked') : input.val();
         // If nonBlank and valueToCheck are both truthy, or nonBlank and valueToCheck are both falsey
         if (!valueToCheck === !nonBlank) {
 
           // Don't count unchecked required radio if other radio with same name is checked
-          if (input.is(':radio') && allInputs.filter('input:radio:checked[name="' + input.attr('name') + '"]').length) {
+          if (input.is('input[type=radio]') && allInputs.filter('input[type=radio]:checked[name="' + input.attr('name') + '"]').length) {
             return true; // Skip to next input
           }
 


### PR DESCRIPTION
Shorthand form selectors in jQuery such as :file, :radio, :checkbox and others have been deprecated. I've replaced any instances with the standard type which has always been supported. For example, :file now is input[type=file]. There are a few instances in rails.js where this was already being done so I stuck to the same format (no quotes on attribute value).

Deprecation details: http://api.jquery.com/category/deprecated/.
Form selector deprecation ticket: http://bugs.jquery.com/ticket/9400

Using the standard selector (e.g. input[type=file]) provides better performance in modern browsers.
