### PR TITLE
Avoid setting withCredentials to null. Fixes #295. Fixes #279.

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -164,11 +164,17 @@
           error: function(xhr, status, error) {
             element.trigger('ajax:error', [xhr, status, error]);
           },
-          xhrFields: {
-            withCredentials: withCredentials
-          },
           crossDomain: crossDomain
         };
+
+        // There is no withCredentials for IE6-8 when
+        // "Enable native XMLHTTP support" is disabled
+        if (withCredentials) {
+          options.xhrFields = {
+            withCredentials: withCredentials
+          };
+        }
+
         // Only pass url to `ajax` options if not blank
         if (url) { options.url = url; }
 


### PR DESCRIPTION
This should fix problems with IE6-8 when "Enable native XMLHTTP support" is disabled. For more details see https://github.com/jquery/jquery/pull/751#issuecomment-11837921

This will fix rails_ujs compatibility with existing jQuery versions so that we don't have to wait while it is fixed in jQuery side and avoid IE headaches for rails_ujs users.
