### PR TITLE
set request Content-Type for data-remote links

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -115,6 +115,10 @@
           type: method || 'GET', data: data, dataType: dataType,
           // stopping the "ajax:beforeSend" event will cancel the ajax request
           beforeSend: function(xhr, settings) {
+            if (settings.type == 'POST') {
+              xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+            }
+
             if (settings.dataType === undefined) {
               xhr.setRequestHeader('accept', '*/*;q=0.5, ' + settings.accepts.script);
             }

--- a/test/public/test/data-remote.js
+++ b/test/public/test/data-remote.js
@@ -78,6 +78,21 @@ asyncTest('clicking on a link with data-remote attribute', 5, function() {
     .trigger('click');
 });
 
+asyncTest('clicking on a link with data-remote attribute and data-method post', 6, function() {
+  $('a[data-remote]')
+    .attr('data-method', 'post')
+    .bind('ajax:success', function(e, data, status, xhr) {
+      App.assert_callback_invoked('ajax:success');
+      App.assert_request_path(data, '/echo');
+      equal(data.CONTENT_TYPE, 'application/x-www-form-urlencoded; charset=UTF-8', 'Content-Type header should be set');
+      equal(data.params.data1, 'value1', 'ajax arguments should have key data1 with right value');
+      equal(data.params.data2, 'value2', 'ajax arguments should have key data2 with right value');
+      App.assert_post_request(data);
+    })
+    .bind('ajax:complete', function() { start() })
+    .trigger('click');
+});
+
 asyncTest('changing a select option with data-remote attribute', 5, function() {
   $('form')
     .append(


### PR DESCRIPTION
This pull request sets the Content-Type header to 'application/x-www-form-urlencoded; charset=UTF-8' for Ajax requests generated for links with data-remote="true" and data-method="post".

Without this patch, no Content-Type header is included in the requests that jquery-ujs generates for these links. Tools such as capybara-webkit issue repeated warnings about these missing headers and these warnings clutter the display of test results (see https://github.com/thoughtbot/capybara-webkit/issues/260).

I've added an appropriate test that passes on Chrome, Safari, Firefox and IE 7-10.
