### PR TITLE
Add data-params handling to handleMethod

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -186,6 +186,7 @@
       var href = rails.href(link),
         method = link.data('method'),
         target = link.attr('target'),
+        params = link.data('params'),
         csrf_token = $('meta[name=csrf-token]').attr('content'),
         csrf_param = $('meta[name=csrf-param]').attr('content'),
         form = $('<form method="post" action="' + href + '"></form>'),
@@ -193,6 +194,12 @@
 
       if (csrf_param !== undefined && csrf_token !== undefined) {
         metadata_input += '<input name="' + csrf_param + '" value="' + csrf_token + '" type="hidden" />';
+      }
+      
+      if(params) {
+        for(key in params) {
+          metadata_input += '<input name="' + key + '" value="' + params[key] + '" type="hidden" />';
+        }
       }
 
       if (target) { form.attr('target', target); }


### PR DESCRIPTION
This commit adds the functionality to fetch the data-params attribute from the link and add fields to the form that express the values from the data-param attributes.

This is useful for POST-requests via links that should post parameters instead of sending them in the URL.
