### PR TITLE
Replacing call to data('events') to allow submit event bubbling to work in IE8

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -253,7 +253,7 @@
     // find all the submit events directly bound to the form and
     // manually invoke them. If anyone returns false then stop the loop
     callFormSubmitBindings: function(form, event) {
-      var events = form.data('events'), continuePropagation = true;
+      var events = jQuery._data(form, 'events'), continuePropagation = true;
       if (events !== undefined && events['submit'] !== undefined) {
         $.each(events['submit'], function(i, obj){
           if (typeof obj.handler === 'function') return continuePropagation = obj.handler(event);


### PR DESCRIPTION
We have an application that uses jquery-ujs (through jquery-rails).  We are upgrading to jQuery 1.9.1 and we ran into some issues with submit event bubbling in IE8.  Since we are also using the jQuery Migrate plugin, it gives us a warning whenever `.data('event')` is invoked.  Turns out the culprit is line 256 of rails.js inside `callFormSubmitBindings`:

``` javascript
var events = form.data('events'), continuePropagation = true;
```

A bit of searching yielded the following from the jQuery blog (http://blog.jquery.com/2012/08/09/jquery-1-8-released/): 

> $(element).data(“events”): In version 1.6, jQuery separated its internal data from the user’s data to prevent name collisions. However, some people were using the internal undocumented “events” data structure so we made it possible to still retrieve that via .data(). This is now removed in 1.8, but you can still get to the events data for debugging purposes via $._data(element, "events"). Note that this is not a supported public interface; the actual data structures may change incompatibly from version to version.

Unfortunately, there is no public API alternative if data('events') is still relied upon (as it seems to be in this library).  In jQuery 1.9.1, the internal API is still there and using it makes the submit event bubbling work again (necessary for < IE9 only).  

I would appreciate your thoughts on this.

Jason
