### PR TITLE
Skip the confirm behaviour.

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -58,9 +58,14 @@
 
     // Triggers an event on an element and returns false if the event result is false
     fire: function(obj, name, data) {
+      return rails.fireNoCheck(obj, name, data) !== false;
+    },
+
+    // Triggers an event on an element and returns the event result
+    fireNoCheck: function(obj, name, data) {
       var event = $.Event(name);
       obj.trigger(event, data);
-      return event.result !== false;
+      return event.result;
     },
 
     // Default confirm dialog, may be overridden with custom confirm dialog in $.rails.confirm
@@ -207,16 +212,25 @@
       - Fires the `confirm:complete` event
 
       Returns `true` if no function stops the chain and user chose yes; `false` otherwise.
-      Attaching a handler to the element's `confirm` event that returns a `falsy` value cancels the confirmation dialog.
+      Attaching a handler to the element's `confirm` event that returns a `falsy` value cancels the confirmation dialog
+      and makes this function return false.
+      Attaching a handler to the element's `confirm` event that returns the string "skip" cancels the confirmation dialog
+      and makes this function return true.
       Attaching a handler to the element's `confirm:complete` event that returns a `falsy` value makes this function
       return false. The `confirm:complete` event is fired whether or not the user answered true or false to the dialog.
    */
     allowAction: function(element) {
       var message = element.data('confirm'),
-          answer = false, callback;
+          answer = false, callback, confirm;
+
       if (!message) { return true; }
 
-      if (rails.fire(element, 'confirm')) {
+      confirm = rails.fireNoCheck(element, 'confirm');
+
+      if(confirm === 'skip') {
+         return true;
+      }
+      else if (confirm !== false) {
         answer = rails.confirm(message);
         callback = rails.fire(element, 'confirm:complete', [answer]);
       }

--- a/test/public/test/data-confirm.js
+++ b/test/public/test/data-confirm.js
@@ -99,3 +99,28 @@ asyncTest('binding to confirm:complete event and returning false', 2, function()
     start();
   }, 50);
 });
+
+asyncTest('binding to confirm event and return "skip"', 4, function() {
+  // redefine confirm function so we can make sure it's not called
+  window.confirm = function(msg) {
+    ok(false, 'confirm dialog should not be called');
+  }
+
+  $('a[data-confirm]')
+    .bind('confirm', function() {
+      App.assert_callback_invoked('confirm');
+      return 'skip';
+    })
+    .bind('confirm:complete', function(e, data) {
+      App.assert_callback_not_invoked('confirm:complete')
+    })
+    .bind('ajax:success', function(e, data, status, xhr) {
+      App.assert_callback_invoked('ajax:success');
+      App.assert_request_path(data, '/echo');
+      App.assert_get_request(data);
+    })
+    .trigger('click');
+  setTimeout(function() {
+    start();
+  }, 50);
+});


### PR DESCRIPTION
In a practical case, when a checkbox in the page is checked, I need to skip the confirmation on a button click with a "data-confirm" message, and perform the action without the user confirmation.

The only way I have found is to patch the ujs code: when the "confirm" event returns the string "skip" the action is performed, exactly as when the "data-confirm" is not set.
