### PR TITLE
Adding bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "main": "src/rails.js",
   "license": "MIT",
   "dependencies": {
-    "jquery": "1.*.*"
+    "jquery": ">1.7.* <2.0.0"
   },
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Howdy, here's a pull request to add a bower.json file which exposes the rails.js file directly, so instead of doing the following in your Rails 4 Sprockets file:

``` javascript
//= require jquery-ujs/src/rails
```

You can now, simply, use: 

``` javascript
//= require jquery-ujs
```

Also, this makes the package a bit trimmer by omitting files that aren't needed such as Gemfile and Rakefile, the latter of which makes precompiling assets a pain.
