### PR TITLE
Refs https://github.com/rails/jquery-ujs/issues/338

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -184,7 +184,7 @@
     disableFormElements: function(form) {
       form.find(rails.disableSelector).each(function() {
         var element = $(this), method = element.is('button') ? 'html' : 'val';
-        element.data('ujs:enable-with', element[method]());
+        if (!element.data('ujs:enable-with')) element.data('ujs:enable-with', element[method]());
         element[method](element.data('disable-with'));
         element.prop('disabled', true);
       });
@@ -197,7 +197,10 @@
     enableFormElements: function(form) {
       form.find(rails.enableSelector).each(function() {
         var element = $(this), method = element.is('button') ? 'html' : 'val';
-        if (element.data('ujs:enable-with')) element[method](element.data('ujs:enable-with'));
+        if (element.data('ujs:enable-with')){
+            element[method](element.data('ujs:enable-with'));
+            element.data('ujs:enable-with', null);
+        }
         element.prop('disabled', false);
       });
     },


### PR DESCRIPTION
Using jquery-remotipart I've got some strange behaviour that could be avoided by doing a little change in disableFormElement function. The problem occurs when this function gets called a second time when the submit button has already been disabled. When this happens, it is not possible to get the original text show at the button when it is enabled back since the "ujs-enabla-with" attribute has been overwritten with the "disabled-with" text in the second call to the disableFormElement. I wonder if this function shouldn't check if ujs-enable-with already exists and, in that case, don't overwrite it.
