### PR TITLE
fix for disabling non-remote links

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -183,6 +183,19 @@
       form.submit();
     },
 
+    // Follow the href after a delay. To be used instead of the default handler to give the DOM a chance to render any changes
+    followLink: function(link) {
+      var href = rails.href(link),
+        target = $.trim(link.attr("target"));
+      setTimeout(function() {
+        if (target) {
+          open(href, target);
+        } else {
+          location = href;
+        }
+      }, 0);
+    },
+
     /* Disables form elements:
       - Caches element value in 'ujs:enable-with' data store
       - Replaces element text with value of 'data-disable-with' attribute
@@ -315,6 +328,9 @@
 
       } else if (link.data('method')) {
         rails.handleMethod(link);
+        return false;
+      } else {
+        rails.followLink(link);
         return false;
       }
     });

--- a/test/public/test/call-remote.js
+++ b/test/public/test/call-remote.js
@@ -96,7 +96,7 @@ asyncTest('allow empty form "action"', 1, function() {
         currentLocation.href = "";
         currentLocation = currentLocation.href;
       }
-      currentLocation = currentLocation.replace(/\?$/, '');
+      currentLocation = currentLocation.replace(/\??#?$/, '');
 
       // Actual location (strip out settings.data that jQuery serializes and appends)
       // HACK: can no longer use settings.data below to see what was appended to URL, as of

--- a/test/public/test/data-disable.js
+++ b/test/public/test/data-disable.js
@@ -18,7 +18,7 @@ module('data-disable', {
 
     $('#qunit-fixture').append($('<a />', {
       text: 'Click me',
-      href: '/echo',
+      href: '#',
       'data-disable-with': 'clicking...'
     }));
   },


### PR DESCRIPTION
Fixes #306, probably also fixes #355.

Non-remote links' default handler is now slightly delayed so that browsers repaint the link with their new disable text/status (this is an issue in Safari and Chrome). This change also fixes an issue in IE where a link with a disable-with attribute around a div doesn't perform the default event handler. As a side effect of this change, calling .trigger('click') on a link will now actually change the window's location - changed a fixture and a test to deal with this.
#361 demonstrates the two problems which are fixed by this change.

If you don't like the changes to the tests, we could alternatively overwrite $.rails.followLink to not do anything during the unit tests.

I ran the unit tests with random jQuery versions (mostly 1.11.0, though) successfully (except for #359) in:
Safari 7, OSX 10.9
Firefox 27, OSX 10.9
Chrome 33, OSX 10.9
IE11, Win8.1 (emulated)
IE10, Win8 (emulated)
IE9, Win7 (emulated)
IE8, Win7 (emulated)
IE7, Vista (emulated)

I tested my Rails app with this change and jQuery 1.11.0 successfully in
Mobile Safari 7, iOS 7
Android Browser 4.3 (emulated)
Android Browser 4.0.3 (emulated)
Safari 7, OSX 10.9
Firefox 27, OSX 10.9
Chrome 33, OSX 10.9
IE11, Win8.1 (emulated)
IE10, Win8 (emulated)
IE9, Win7 (emulated)
IE8, Win7 (emulated)
IE7, Vista (emulated)
