### PR TITLE
Include instructions for installation via Bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Requirements
 
 If you don't use HTML5, adding "data" attributes to your HTML4 or XHTML pages might make them fail [W3C markup validation][validator]. However, this shouldn't create any issues for web browsers or other user agents.
 
-Installation
+Installation using the jQuery-Rails Gem
 ------------
 
 For automated installation in Rails, use the "jquery-rails" gem. Place this in your Gemfile:
@@ -51,6 +51,29 @@ Choose to overwrite jquery_ujs.js if prompted.*
     $ rails generate jquery:install
 
 c. For Rails 2.x and for manual installation follow [this wiki](https://github.com/rails/jquery-ujs/wiki/Manual-installing-and-Rails-2) .
+
+Installation using Bower
+------------
+
+Modify your bower.json file and add jQuery-UJS as a dependency as follows:
+
+```javascript
+{
+    "dependencies": {
+        /* include jQuery-UJS as below */
+        "jquery-ujs": "git@github.com:rails/jquery-ujs.git"
+    }
+}
+```
+
+Then run `bower install jquery-ujs` to install the jQuery-UJS package.
+
+For Rails 3.1 and above, add these lines to the top of your app/assets/javascripts/application.js file:
+
+```javascript
+//= require jquery
+//= require jquery-ujs/src/rails
+```
 
 How to run tests
 ------------


### PR DESCRIPTION
The installation instructions for Bower are incorrect as the require path is invalid.

This commit simply adds installation instructions for Bower.  As `bower.json` is included in this repository, clearly support for Bower is intended.
