### PR TITLE
Re-enables buttons and links after going back

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -322,6 +322,29 @@
 
     $.ajaxPrefilter(function(options, originalOptions, xhr){ if ( !options.crossDomain ) { rails.CSRFProtection(xhr); }});
 
+    // This event works the same as the load event, except that it fires every
+    // time the page is loaded.
+    //
+    // See https://github.com/rails/jquery-ujs/issues/357
+    // See https://developer.mozilla.org/en-US/docs/Using_Firefox_1.5_caching
+    $(window).on("pageshow.rails", function () {
+      $($.rails.enableSelector).each(function () {
+        var element = $(this);
+
+        if (element.data("ujs:enable-with")) {
+          $.rails.enableFormElement(element);
+        }
+      });
+
+      $($.rails.linkDisableSelector).each(function () {
+        var element = $(this);
+
+        if (element.data("ujs:enable-with")) {
+          $.rails.enableElement(element);
+        }
+      });
+    });
+
     $document.delegate(rails.linkDisableSelector, 'ajax:complete', function() {
         rails.enableElement($(this));
     });

--- a/test/public/test/data-disable-with.js
+++ b/test/public/test/data-disable-with.js
@@ -99,6 +99,24 @@ asyncTest('form input[type=submit][data-disable-with] disables', 6, function(){
   }, 30);
 });
 
+test('form input[type=submit][data-disable-with] re-enables when `pageshow` event is triggered', function(){
+  var form = $('form:not([data-remote])'), input = form.find('input[type=submit]');
+
+  App.checkEnabledState(input, 'Submit');
+
+  // Emulate the disabled state without submitting the form at all, what is the
+  // state after going back on firefox after submitting a form.
+  //
+  // See https://github.com/rails/jquery-ujs/issues/357
+  $.rails.disableFormElements(form);
+
+  App.checkDisabledState(input, 'submitting ...');
+
+  $(window).trigger('pageshow');
+
+  App.checkEnabledState(input, 'Submit');
+});
+
 asyncTest('form[data-remote] input[type=submit][data-disable-with] is replaced in ajax callback', 2, function(){
   var form = $('form:not([data-remote])').attr('data-remote', 'true'), origFormContents = form.html();
 
@@ -171,6 +189,18 @@ asyncTest('a[data-disable-with] disables', 4, function() {
   link.trigger('click');
   App.checkDisabledState(link, 'clicking...');
   start();
+});
+
+test('a[data-disable-with] re-enables when `pageshow` event is triggered', function() {
+  var link = $('a[data-disable-with]');
+
+  App.checkEnabledState(link, 'Click me');
+
+  link.trigger('click');
+  App.checkDisabledState(link, 'clicking...');
+
+  $(window).trigger('pageshow');
+  App.checkEnabledState(link, 'Click me');
 });
 
 asyncTest('a[data-remote][data-disable-with] disables and re-enables', 6, function() {


### PR DESCRIPTION
Firefox has a weird behavior where when you hit the back button it keeps
the submit buttons and links on disabled state which even reloading the
page do not re-enables them.

Using the pageshow event, which is triggered every time a page loads, we
can keep the rails-ujs behavior consistent with all other browsers.

See https://developer.mozilla.org/en-US/docs/Using_Firefox_1.5_caching

[Fixes #357]
