### PR TITLE
Add support for "formaction" and "formmethod" attributes in remote forms

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -100,8 +100,8 @@
         dataType = element.data('type') || ($.ajaxSettings && $.ajaxSettings.dataType);
 
         if (element.is('form')) {
-          method = element.attr('method');
-          url = element.attr('action');
+          method = element.data('ujs:submit-button-formmethod') || element.attr('method');
+          url = element.data('ujs:submit-button-formaction') || element.attr('action');
           data = element.serializeArray();
           // memoized value from clicked submit button
           var button = element.data('ujs:submit-button');
@@ -109,6 +109,8 @@
             data.push(button);
             element.data('ujs:submit-button', null);
           }
+          element.data('ujs:submit-button-formmethod', null)
+          element.data('ujs:submit-button-formaction', null)
         } else if (element.is(rails.inputChangeSelector)) {
           method = element.data('method');
           url = element.data('url');
@@ -450,7 +452,10 @@
       var name = button.attr('name'),
         data = name ? {name:name, value:button.val()} : null;
 
-      button.closest('form').data('ujs:submit-button', data);
+      button.closest('form')
+        .data('ujs:submit-button', data)
+        .data('ujs:submit-button-formaction', button.attr('formaction'))
+        .data('ujs:submit-button-formmethod', button.attr('formmethod'));
     });
 
     $document.delegate(rails.formSubmitSelector, 'ajax:send.rails', function(event) {

--- a/test/public/test/call-remote.js
+++ b/test/public/test/call-remote.js
@@ -32,6 +32,19 @@ asyncTest('form method is not read from "data-method" attribute in case of missi
   });
 });
 
+asyncTest('form method is read from submit button "formmethod" if submit is triggered by that button', 1, function() {
+  var submitButton = $('<input type="submit" formmethod="get">')
+  buildForm({ method: 'post' });
+
+  $('#qunit-fixture').find('form').append(submitButton)
+    .bind('ajax:success', function(e, data, status, xhr) {
+      App.assertGetRequest(data);
+    })
+    .bind('ajax:complete', function() { start() });
+
+  submitButton.trigger('click');
+});
+
 asyncTest('form default method is GET', 1, function() {
   buildForm();
 
@@ -54,6 +67,19 @@ asyncTest('form url is read from "action" not "href"', 1, function() {
   submit(function(e, data, status, xhr) {
     App.assertRequestPath(data, '/echo');
   });
+});
+
+asyncTest('form url is read from submit button "formaction" if submit is triggered by that button', 1, function() {
+  var submitButton = $('<input type="submit" formaction="/echo">')
+  buildForm({ method: 'post', href: '/echo2' });
+
+  $('#qunit-fixture').find('form').append(submitButton)
+    .bind('ajax:success', function(e, data, status, xhr) {
+      App.assertRequestPath(data, '/echo');
+    })
+    .bind('ajax:complete', function() { start() });
+
+  submitButton.trigger('click');
 });
 
 asyncTest('prefer JS, but accept any format', 1, function() {


### PR DESCRIPTION
This patch prevents situation when "formaction" and "formmethod" attributes are ignored on remote form submit. More about that attributes in http://www.w3.org/TR/html5/forms.html#form-submission