### PR TITLE
data-method whitelist to block adding CSRF

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -178,7 +178,7 @@
         form = $('<form method="post" action="' + href + '"></form>'),
         metadataInput = '<input name="_method" value="' + method + '" type="hidden" />';
 
-      if (csrfParam !== undefined && csrfToken !== undefined) {
+      if (rails.isCsrfHrefWhitelisted(href) && csrfParam !== undefined && csrfToken !== undefined) {
         metadataInput += '<input name="' + csrfParam + '" value="' + csrfToken + '" type="hidden" />';
       }
 
@@ -256,6 +256,11 @@
         callback = rails.fire(element, 'confirm:complete', [answer]);
       }
       return answer && callback;
+    },
+
+    // Verify, when configured, that the href passes the whitelist for CSRF token usage.
+    isCsrfHrefWhitelisted: function(href){
+      return rails.csrfWhitelistedHrefs ? rails.csrfWhitelistedHrefs.test(href) : true;
     },
 
     // Helper function which checks for blank inputs in a form that match the specified CSS selector

--- a/test/public/test/data-method.js
+++ b/test/public/test/data-method.js
@@ -39,6 +39,19 @@ asyncTest('link with "data-method" and CSRF', 1, function() {
   });
 });
 
+asyncTest('non whitelisted links with "data-method" get no CSRF', 2, function() {
+    $.rails.csrfWhitelistedHrefs = /http:\/\/rubyonrails.org/
+
+    $('#qunit-fixture')
+        .append('<meta name="csrf-param" content="authenticity_token"/>')
+        .append('<meta name="csrf-token" content="cf50faa3fe97702ca1ae"/>');
+
+    submit(function(data) {
+        strictEqual(data.params.authenticity_token, undefined);
+        strictEqual(data.HTTP_X_CSRF_TOKEN, undefined);
+    });
+});
+
 asyncTest('link "target" should be carried over to generated form', 1, function() {
   $('a[data-method]').attr('target', 'super-special-frame');
   submit(function(data) {


### PR DESCRIPTION
If an attacker has the ability to create link tags and attributes they have the ability to intercept the CSRF token, even if CSP is enabled. By setting the href to another site and adding `data-method='post'` the CSRF token will automatically be added to the request and sent to an attackers site. It is important to note that this is only applicable to `handleMethod` (`data-method`) call as when done through `handleRemote` (`data-remote`) the CSP will block the request to the attackers domain.

This fix adds a configurable whitelist of hrefs to verify the link against before adding the CSRF token. The default is to allow everything to avoid break existing clients.