### PR TITLE
Added support for data-params on form elements

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -103,6 +103,18 @@
           method = element.attr('method');
           url = element.attr('action');
           data = element.serializeArray();
+
+          if(element.data("params")){
+            var paramList = element.data("params").split("&")
+            paramList.forEach(function(item){ 
+              var parts = item.split("=");
+              var obj = {}
+              obj["name"] = parts[0]
+              obj["value"] = parts[1]
+              data.push(obj)
+            })
+          }
+
           // memoized value from clicked submit button
           var button = element.data('ujs:submit-button');
           if (button) {

--- a/test/public/test/data-remote.js
+++ b/test/public/test/data-remote.js
@@ -16,6 +16,7 @@ module('data-remote', {
       .append($('<form />', {
         action: '/echo',
         'data-remote': 'true',
+        'data-params': "save=auto&data1=value1",
         method: 'post'
       }))
       .find('form').append($('<input type="text" name="user_name" value="john">'));
@@ -123,12 +124,14 @@ asyncTest('changing a select option with data-remote attribute', 5, function() {
     .trigger('change');
 });
 
-asyncTest('submitting form with data-remote attribute', 4, function() {
+asyncTest('submitting form with data-remote attribute', 6, function() {
   $('form[data-remote]')
     .bind('ajax:success', function(e, data, status, xhr) {
       App.assertCallbackInvoked('ajax:success');
       App.assertRequestPath(data, '/echo');
       equal(data.params.user_name, 'john', 'ajax arguments should have key user_name with right value');
+      equal(data.params.save, 'auto', 'ajax arguments should have key save with right value');
+      equal(data.params.data1, 'value1', 'ajax arguments should have key data1 with right value');
       App.assertPostRequest(data);
     })
     .bind('ajax:complete', function() { start() })


### PR DESCRIPTION
To make support for form elements consistent with the other elements supporting `data-params`, I add the ability to add `data-params` to form elements.

Added a couple basic tests. All tests are currently passing and I've tested on the latest versions of Safari, Chrome, Firefox and Opera.