### PR TITLE
Extract csrfToken and csrfParam to allow external use

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -54,17 +54,25 @@
     // Button onClick disable selector with possible reenable after remote submission
     buttonDisableSelector: 'button[data-remote][data-disable-with], button[data-remote][data-disable]',
 
+    // Up-to-date Cross-Site Request Forgery token
+    csrfToken: function() {
+     return $('meta[name=csrf-token]').attr('content');
+    },
+
+    // URL param that must contain the CSRF token
+    csrfParam: function() {
+     return $('meta[name=csrf-param]').attr('content');
+    },
+
     // Make sure that every Ajax request sends the CSRF token
     CSRFProtection: function(xhr) {
-      var token = $('meta[name="csrf-token"]').attr('content');
+      var token = rails.csrfToken();
       if (token) xhr.setRequestHeader('X-CSRF-Token', token);
     },
 
     // making sure that all forms have actual up-to-date token(cached forms contain old one)
     refreshCSRFTokens: function(){
-      var csrfToken = $('meta[name=csrf-token]').attr('content');
-      var csrfParam = $('meta[name=csrf-param]').attr('content');
-      $('form input[name="' + csrfParam + '"]').val(csrfToken);
+      $('form input[name="' + rails.csrfParam() + '"]').val(rails.csrfToken());
     },
 
     // Triggers an event on an element and returns false if the event result is false

--- a/test/public/test/csrf-token.js
+++ b/test/public/test/csrf-token.js
@@ -1,0 +1,27 @@
+(function(){
+
+module('csrf-token', {});
+
+asyncTest('find csrf token', 1, function() {
+  var correctToken = "cf50faa3fe97702ca1ae";
+
+  $('#qunit-fixture').append('<meta name="csrf-token" content="' + correctToken + '"/>');
+
+  currentToken = $.rails.csrfToken();
+
+  start();
+  equal(currentToken, correctToken);
+});
+
+asyncTest('find csrf param', 1, function() {
+  var correctParam = "authenticity_token";
+
+  $('#qunit-fixture').append('<meta name="csrf-param" content="' + correctParam + '"/>');
+
+  currentParam = $.rails.csrfParam();
+
+  start();
+  equal(currentParam, correctParam);
+});
+
+})();

--- a/test/views/index.erb
+++ b/test/views/index.erb
@@ -1,6 +1,6 @@
 <% @title = "jquery-ujs test" %>
 
-<%= test 'data-confirm', 'data-remote', 'data-disable', 'data-disable-with', 'call-remote', 'call-remote-callbacks', 'data-method', 'override', 'csrf-refresh' %>
+<%= test 'data-confirm', 'data-remote', 'data-disable', 'data-disable-with', 'call-remote', 'call-remote-callbacks', 'data-method', 'override', 'csrf-refresh', 'csrf-token' %>
 
 <h1 id="qunit-header"><%= @title %></h1>
 <div id="jquery-cdn">


### PR DESCRIPTION
I would like to use the CSRF token independently from the jQuery UJS library.

Rather than copy-pasting the jQuery snippet `$('meta[name=csrf-token]').attr('content')` into my own code I propose to extract it to its own method so I can refer to it like this: `$.rails.csrfToken()`

My use case is to render client-side templates that include forms. This way I can render the CSRF at the same time as the other content:

```erb
<div class="modal fade">
  <div class="modal-dialog">
    <div class="modal-content">
      <form class="edit_comment" action="/comments/<%= @id %>" accept-charset="UTF-8" method="post">
        <input name="utf8" type="hidden" value="✓">
        <input name="_method" type="hidden" value="patch">
        <input type="hidden" name="<%= $.rails.csrfParam() %>" value="<%= $.rails.csrfToken() %>">
        <div class="modal-header">
          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
          <h4 class="modal-title">Edit Comment</h4>
        </div>
        <div class="modal-body">
          <textarea class="form-control" rows="5" name="comment[body]" id="comment_body"><%= @body %></textarea>
        </div>
        <div class="modal-footer">
          <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
          <button type="submit" class="btn btn-primary">Update</button>
        </div>
      </form>
    </div>
  </div>
</div>
```