### PR TITLE
Links with [disabled] attribute set will not trigger AJAX

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -22,7 +22,7 @@
 
   $.rails = rails = {
     // Link elements bound by jquery-ujs
-    linkClickSelector: 'a[data-confirm], a[data-method], a[data-remote], a[data-disable-with], a[data-disable]',
+    linkClickSelector: 'a[data-confirm], a[data-method], a[data-remote]:not([disabled]), a[data-disable-with], a[data-disable]',
 
     // Button elements bound by jquery-ujs
     buttonClickSelector: 'button[data-remote]:not(form button), button[data-confirm]:not(form button)',

--- a/test/public/test/data-remote.js
+++ b/test/public/test/data-remote.js
@@ -18,6 +18,12 @@ module('data-remote', {
         'data-remote': 'true',
         method: 'post'
       }))
+      .append($('<a />', {
+        href: '/echo',
+        'data-remote': 'true',
+        disabled: 'disabled',
+        text: 'Disabed link'
+      }))
       .find('form').append($('<input type="text" name="user_name" value="john">'));
 
   }
@@ -82,6 +88,19 @@ asyncTest('clicking on a link with data-remote attribute', 5, function() {
     })
     .bind('ajax:complete', function() { start() })
     .trigger('click');
+});
+
+asyncTest('clicking on a link with disabled attribute', 0, function() {
+  $('a[disabled]')
+  .bind("ajax:before", function(e, data, status, xhr) {
+    App.assertCallbackNotInvoked('ajax:success')
+  })
+  .bind('ajax:complete', function() { start() })
+  .trigger('click')
+
+  setTimeout(function() {
+    start();
+  }, 13);
 });
 
 asyncTest('clicking on a button with data-remote attribute', 5, function() {


### PR DESCRIPTION
This is a PR that would fix the issue some of us had (#317). It would disable HTML Anchor element that have the [disabled] attribute set. I'm aware that this is not per HTML's Standard but I think it's useful nonetheless.

All the tests are green, but I'm open to ideas/changes to this PR.