### PR TITLE
Treat confirm exception as false

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -260,7 +260,11 @@
       if (!message) { return true; }
 
       if (rails.fire(element, 'confirm')) {
-        answer = rails.confirm(message);
+        try {
+          answer = rails.confirm(message);
+        } catch (e) {
+          (console.error || console.log).call(console, e.stack || e);
+        }
         callback = rails.fire(element, 'confirm:complete', [answer]);
       }
       return answer && callback;

--- a/test/public/test/data-confirm.js
+++ b/test/public/test/data-confirm.js
@@ -117,6 +117,27 @@ asyncTest('clicking on a button with data-confirm attribute. Confirm No.', 3, fu
   }, 50);
 });
 
+asyncTest('clicking on a button with data-confirm attribute. Confirm error.', 3, function() {
+  var message;
+  // auto-decline:
+  window.confirm = function(msg) { message = msg; throw "some random error"; };
+
+  $('button[data-confirm]')
+    .bind('confirm:complete', function(e, data) {
+      App.assertCallbackInvoked('confirm:complete');
+      ok(data == false, 'confirm:complete passes in confirm answer (false)');
+    })
+    .bind('ajax:beforeSend', function(e, data, status, xhr) {
+      App.assertCallbackNotInvoked('ajax:beforeSend');
+    })
+    .trigger('click');
+
+  setTimeout(function() {
+    equal(message, 'Are you absolutely sure?');
+    start();
+  }, 50);
+});
+
 asyncTest('clicking on a submit button with form and data-confirm attributes. Confirm No.', 3, function() {
   var message;
   // auto-decline:


### PR DESCRIPTION
An exception thrown during $.rails.confirm should not be treated as a successful confirmation.

For example, the js popup blocker on Firefox throws an exception on window.confirm() after the user selects 'Prevent this page from creating additional dialogs". Subsequent clicks on data-confirm links/buttons should not succeed because there is no user confirmation.