### PR TITLE
Restore $.rails.href original behavior.

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -94,7 +94,7 @@
 
     // Default way to get an element's href. May be overridden at $.rails.href.
     href: function(element) {
-      return element[0].href;
+      return element.attr("href");
     },
 
     // Submits "remote" forms and links with ajax

--- a/test/public/test/override.js
+++ b/test/public/test/override.js
@@ -32,7 +32,7 @@ asyncTest("the getter for an element's href is overridable", 1, function() {
 
 asyncTest("the getter for an element's href works normally if not overridden", 1, function() {
   $.rails.ajax = function(options) {
-    equal(location.protocol + '//' + location.host + '/real/href', options.url);
+    equal('/real/href', options.url);
   }
   $.rails.handleRemote($('#qunit-fixture').find('a'));
   start();


### PR DESCRIPTION
This PR restores a way how to get element's `href`, which was used before the [security fix](https://github.com/rails/jquery-ujs/commit/8c44135892c875acd0375ec344e69d83c199a6c8).

Suggested `element[0].href` works only for `<a>` and `<link>` elements. That makes impossible use-cases like this one:
```ruby
<%= div_for(object, data: { method: "put" }, href: url) do %>
  ...
  <%= link_to "Delete", url, remote: true, method: :delete %>
<% end %>
```
At the same time `element.attr("href")` allows to work with all types of elements.

It looks like that `.href` method was introduced because it returns a full url, including protocol and host, which are necessary for `isCrossDomain()` check.

But restoring original behavior won't brake the `isCrossDomain()` check because of a [workaround](https://github.com/rails/jquery-ujs/blob/v1.0.4/src/rails.js#L176-L177) that was used for IE bag fix.

```javascript
urlAnchor.href = url;
// This is a workaround to a IE bug.
urlAnchor.href = urlAnchor.href;
```
This workaround converts any local url assigned to `urlAnchor.href` to a full url, while keeps the remote url untouched. But even without that workaround any local url correctly returns `.protocol` and `.host`.

Please, let me know if I'm missing something.