### PR TITLE
Ignore disabled file input

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -48,7 +48,7 @@
     requiredInputSelector: 'input[name][required]:not([disabled]),textarea[name][required]:not([disabled])',
 
     // Form file input elements
-    fileInputSelector: 'input[type=file]',
+    fileInputSelector: 'input[type=file]:not([disabled])',
 
     // Link onClick disable selector with possible reenable after remote submission
     linkDisableSelector: 'a[data-disable-with], a[data-disable]',


### PR DESCRIPTION
Disabled file input form should be ignored,
however currently submitting a form with disabled file input will cause issue on Rails' side.

A minimal demo is provided: https://github.com/lulalala/ujs-bug
There are 2 commits, the first one is before the patch, the second one is after the patch.
Run the app, navigate to http://localhost:3000/posts/new
Choose a file, and then that file will be disabled. Then submit the form.
Before the patch, form submission will raise `ActionController::InvalidAuthenticityToken`
After the patch, form submission will be successful (the file input will be ignored completely).

This demo may seem a bit contrived, but in my actual app I have a valid requirement that is using ujs together with remotipart and conditional file input.

If someone can give me some idea as to how to test this it would be great. Thanks.