### PR TITLE
fix for IE7 relative links

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -182,14 +182,17 @@
 
     // Determines if the request is a cross domain request.
     isCrossDomain: function(url) {
+      var regexp = new RegExp('^\\s*(?:[a-z]+:)?//', 'i');
+      if(!regexp.test(url)) {
+        return false;
+      }
+
       var originAnchor = document.createElement('a');
       originAnchor.href = location.href;
       var urlAnchor = document.createElement('a');
 
       try {
         urlAnchor.href = url;
-        // This is a workaround to a IE bug.
-        urlAnchor.href = urlAnchor.href;
 
         // Make sure that the browser parses the URL and that the protocols and hosts match.
         return !urlAnchor.protocol || !urlAnchor.host ||


### PR DESCRIPTION
Relative links in IE7 are breaking because the protocol and host aren't being set correctly in the cross domain checking. Instead, this uses a regexp to check if the link is relative, in which case it is definitively not a cross-domain request. Because of this the urlAnchor.href = urlAnchor.href workaround is no longer necessary.