### PR TITLE
Disabled blank inputs don't reset on ajax submit

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -266,7 +266,7 @@
 
     enableFormElement: function(element) {
       var method = element.is('button') ? 'html' : 'val';
-      if (element.data('ujs:enable-with')) element[method](element.data('ujs:enable-with'));
+      if (typeof element.data('ujs:enable-with') !== 'undefined') element[method](element.data('ujs:enable-with'));
       element.prop('disabled', false);
     },
 

--- a/test/public/test/data-disable-with.js
+++ b/test/public/test/data-disable-with.js
@@ -61,6 +61,24 @@ asyncTest('form input field with "data-disable-with" attribute', 7, function() {
   App.checkDisabledState(input, 'processing ...');
 });
 
+asyncTest('blank form input field with "data-disable-with" attribute', 7, function() {
+  var form = $('form[data-remote]'), input = form.find('input[type=text]');
+
+  input.val('');
+  App.checkEnabledState(input, '');
+
+  form.bind('ajax:success', function(e, data) {
+    setTimeout(function() {
+      App.checkEnabledState(input, '');
+      equal(data.params.user_name, '');
+      start();
+    }, 13);
+  });
+  form.trigger('submit');
+
+  App.checkDisabledState(input, 'processing ...');
+});
+
 asyncTest('form button with "data-disable-with" attribute', 6, function() {
   var form = $('form[data-remote]'), button = $('<button data-disable-with="submitting ..." name="submit2">Submit</button>');
   form.append(button);


### PR DESCRIPTION
Submitting a remote form with a blank input using `[data-disable-with]` would cause the `disable-with` message to get stuck since `if("") == false`

![demo](https://cloud.githubusercontent.com/assets/104138/8590333/e388f4ae-261f-11e5-8702-5396d9e9dc53.gif)
