### PR TITLE
Enable UJS on controls using the 'form' attribute

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -115,7 +115,7 @@
         if (element.is('form')) {
           method = element.attr('method');
           url = element.attr('action');
-          data = data = $(element[0].elements).serializeArray();
+          data = $(element[0].elements).serializeArray();
           // memoized value from clicked submit button
           var button = element.data('ujs:submit-button');
           if (button) {

--- a/src/rails.js
+++ b/src/rails.js
@@ -27,7 +27,7 @@
     linkClickSelector: 'a[data-confirm], a[data-method], a[data-remote], a[data-disable-with], a[data-disable]',
 
     // Button elements bound by jquery-ujs
-    buttonClickSelector: 'button[data-remote]:not(form button), button[data-confirm]:not(form button)',
+    buttonClickSelector: 'button[data-remote]:not([form]):not(form button), button[data-confirm]:not([form]):not(form button)',
 
     // Select elements bound by jquery-ujs
     inputChangeSelector: 'select[data-remote], input[data-remote], textarea[data-remote]',
@@ -115,7 +115,7 @@
         if (element.is('form')) {
           method = element.attr('method');
           url = element.attr('action');
-          data = element.serializeArray();
+          data = data = $(element[0].elements).serializeArray();
           // memoized value from clicked submit button
           var button = element.data('ujs:submit-button');
           if (button) {
@@ -491,7 +491,11 @@
       var name = button.attr('name'),
         data = name ? {name:name, value:button.val()} : null;
 
-      button.closest('form').data('ujs:submit-button', data);
+      var form = button.closest('form');
+      if (form.length === 0) {
+        form = $('#' + button.attr('form'));
+      }
+      form.data('ujs:submit-button', data);
     });
 
     $document.delegate(rails.formSubmitSelector, 'ajax:send.rails', function(event) {

--- a/test/public/test/data-remote.js
+++ b/test/public/test/data-remote.js
@@ -16,7 +16,8 @@ module('data-remote', {
       .append($('<form />', {
         action: '/echo',
         'data-remote': 'true',
-        method: 'post'
+        method: 'post',
+        id: 'my-remote-form'
       }))
       .find('form').append($('<input type="text" name="user_name" value="john">'));
 
@@ -133,6 +134,51 @@ asyncTest('submitting form with data-remote attribute', 4, function() {
     })
     .bind('ajax:complete', function() { start() })
     .trigger('submit');
+});
+
+asyncTest('submitting form with data-remote attribute submits input with matching [form] attribute', 5, function() {
+  $('#qunit-fixture')
+    .append($('<input type="text" name="user_data" value="value1" form="my-remote-form">'));
+
+  $('form[data-remote]')
+    .bind('ajax:success', function(e, data, status, xhr) {
+      App.assertCallbackInvoked('ajax:success');
+      App.assertRequestPath(data, '/echo');
+      equal(data.params.user_name, 'john', 'ajax arguments should have key user_name with right value');
+      equal(data.params.user_data, 'value1', 'ajax arguments should have key user_data with right value');
+      App.assertPostRequest(data);
+    })
+    .bind('ajax:complete', function() { start() })
+    .trigger('submit');
+});
+
+asyncTest('submitting form with data-remote attribute by clicking button with matching [form] attribute', 5, function() {
+  $('form[data-remote]')
+    .bind('ajax:success', function(e, data, status, xhr) {
+      App.assertCallbackInvoked('ajax:success');
+      App.assertRequestPath(data, '/echo');
+      equal(data.params.user_name, 'john', 'ajax arguments should have key user_name with right value');
+      equal(data.params.user_data, 'value2', 'ajax arguments should have key user_data with right value');
+      App.assertPostRequest(data);
+    })
+    .bind('ajax:complete', function() { start() });
+
+  $('<button />', {
+        type: "submit",
+        name: "user_data",
+        value: "value1",
+        form: "my-remote-form"
+      })
+    .appendTo($('#qunit-fixture'));
+
+  $('<button />', {
+      type: "submit",
+      name: "user_data",
+      value: "value2",
+      form: "my-remote-form"
+    })
+    .appendTo($('#qunit-fixture'))
+    .trigger('click');
 });
 
 asyncTest('form\'s submit bindings in browsers that don\'t support submit bubbling', 5, function() {


### PR DESCRIPTION
* Ensure disassociated inputs are serialized with the form
* Allow disassociated buttons to submit the form

Two tests added verifying these two points. Both fail on Internet Explorer, as IE does not support the `form` attribute. Unfortunately, the second test hangs on IE, since the expected AJAX submit never happens. I've probably missed a straightforward way to prevent that...