### PR TITLE
Don't replace content if undefine data-disable-with

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -250,12 +250,13 @@
       method = element.is('button') ? 'html' : 'val';
       replacement = element.data('disable-with');
 
-      element.data('ujs:enable-with', element[method]());
       if (replacement !== undefined) {
+        element.data('ujs:enable-with', element[method]());
         element[method](replacement);
       }
 
       element.prop('disabled', true);
+      element.data('ujs:disabled', true);
     },
 
     /* Re-enables disabled form elements:
@@ -270,8 +271,12 @@
 
     enableFormElement: function(element) {
       var method = element.is('button') ? 'html' : 'val';
-      if (typeof element.data('ujs:enable-with') !== 'undefined') element[method](element.data('ujs:enable-with'));
+      if (element.data('ujs:enable-with') !== undefined) {
+        element[method](element.data('ujs:enable-with'));
+        element.removeData('ujs:enable-with'); // clean up cache
+      }
       element.prop('disabled', false);
+      element.removeData('ujs:disabled');
     },
 
    /* For 'data-confirm' attribute:
@@ -339,14 +344,15 @@
     disableElement: function(element) {
       var replacement = element.data('disable-with');
 
-      element.data('ujs:enable-with', element.html()); // store enabled state
       if (replacement !== undefined) {
+        element.data('ujs:enable-with', element.html()); // store enabled state
         element.html(replacement);
       }
 
       element.bind('click.railsDisable', function(e) { // prevent further clicking
         return rails.stopEverything(e);
       });
+      element.data('ujs:disabled', true);
     },
 
     // Restore element to its original state which was disabled by 'disableElement' above
@@ -356,6 +362,7 @@
         element.removeData('ujs:enable-with'); // clean up cache
       }
       element.unbind('click.railsDisable'); // enable element
+      element.removeData('ujs:disabled');
     }
   };
 
@@ -372,7 +379,7 @@
       $($.rails.enableSelector).each(function () {
         var element = $(this);
 
-        if (element.data('ujs:enable-with')) {
+        if (element.data('ujs:disabled')) {
           $.rails.enableFormElement(element);
         }
       });
@@ -380,7 +387,7 @@
       $($.rails.linkDisableSelector).each(function () {
         var element = $(this);
 
-        if (element.data('ujs:enable-with')) {
+        if (element.data('ujs:disabled')) {
           $.rails.enableElement(element);
         }
       });

--- a/test/public/test/data-disable.js
+++ b/test/public/test/data-disable.js
@@ -51,7 +51,7 @@ asyncTest('form input field with "data-disable" attribute', 7, function() {
   App.checkDisabledState(input, 'john');
 });
 
-asyncTest('form button with "data-disable" attribute', 6, function() {
+asyncTest('form button with "data-disable" attribute', 7, function() {
   var form = $('form[data-remote]'), button = $('<button data-disable name="submit2">Submit</button>');
   form.append(button);
 
@@ -66,6 +66,7 @@ asyncTest('form button with "data-disable" attribute', 6, function() {
   form.trigger('submit');
 
   App.checkDisabledState(button, 'Submit');
+  equal(button.data('ujs:enable-with'), undefined);
 });
 
 asyncTest('form input[type=submit][data-disable] disables', 6, function(){
@@ -132,13 +133,14 @@ asyncTest('form[data-remote] textarea[data-disable] attribute', 3, function() {
   App.checkDisabledState(textarea, 'born, lived, died.');
 });
 
-asyncTest('a[data-disable] disables', 4, function() {
+asyncTest('a[data-disable] disables', 5, function() {
   var link = $('a[data-disable]');
 
   App.checkEnabledState(link, 'Click me');
 
   link.trigger('click');
   App.checkDisabledState(link, 'Click me');
+  equal(link.data('ujs:enable-with'), undefined);
   start();
 });
 

--- a/test/public/test/settings.js
+++ b/test/public/test/settings.js
@@ -25,7 +25,7 @@ App.getVal = function(el) {
 };
 
 App.disabled = function(el) {
-  return el.is('input,textarea,select,button') ? el.is(':disabled') : el.data('ujs:enable-with');
+  return el.is('input,textarea,select,button') ? (el.is(':disabled') && el.data('ujs:disabled')) : el.data('ujs:disabled');
 };
 
 App.checkEnabledState = function(el, text) {


### PR DESCRIPTION
Situation:

A button with `data-disable`:

```erb
<button data-disable>Submit</button>
```

When click this button, I want to insert a animation element to button, the animation element is dynamic defined, so it's not suitable for `data-disabled-with` or css hidden.

```erb
<button data-disable>Submit<div class="wave-ripple"></div></button>
```

The animation element will be removed after animation end, but current ujs cache button content to `ujs:enable-with`, even though `data-disabled-with` is undefined. Then it will replace cached content after ajax end, that break my animation effect.

So I change it not to store `ujs:enable-with` if `data-disabled-with` is undefined, then it will not execute a replacement after ajax.

I also use attribute `disabled` to flag disabled state for links instead of data `ujs:enable-with`. So a disabled link can be selected by `a[disabled]` for css style.