### PR TITLE
Ignore file input fields without name attribute. (Refile compatibility)

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -48,7 +48,7 @@
     requiredInputSelector: 'input[name][required]:not([disabled]), textarea[name][required]:not([disabled])',
 
     // Form file input elements
-    fileInputSelector: 'input[type=file]:not([disabled])',
+    fileInputSelector: 'input[name][type=file]:not([disabled])',
 
     // Link onClick disable selector with possible reenable after remote submission
     linkDisableSelector: 'a[data-disable-with], a[data-disable]',

--- a/test/public/test/call-remote-callbacks.js
+++ b/test/public/test/call-remote-callbacks.js
@@ -327,6 +327,27 @@ function skipIt() {
     }, 13);
   });
 
+  asyncTest('file form input field should not abort remote request if file form input does not have a name attribute', 5, function() {
+    var form = $('form[data-remote]')
+          .append($('<input type="file" value="default.png">'))
+          .bind('ajax:beforeSend', function() {
+            ok(true, 'ajax:beforeSend should run');
+          })
+          .bind('iframe:loading', function() {
+            ok(true, 'form should get submitted');
+          })
+          .bind('ajax:aborted:file', function(e,data) {
+            ok(false, 'ajax:aborted:file should not run');
+          })
+          .trigger('submit');
+
+    setTimeout(function() {
+      form.find('input[type="file"]').val('');
+      form.unbind('ajax:beforeSend');
+      submit();
+    }, 13);
+  });
+
   asyncTest('blank file input field should abort request entirely if handler bound to "ajax:aborted:file" event that returns false', 1, function() {
     var form = $('form[data-remote]')
           .append($('<input type="file" name="attachment" value="default.png">'))


### PR DESCRIPTION
Browsers do not submit form fields that do not have a name attribute. Therefore, the jquery-ujs library should also ignore file input fields without a name attribute when filtering to control remote form submission behavior.

The [Refile](https://github.com/refile/refile) ruby gem provides an elegant solution for asynchronous direct-to-S3 file uploads. Currently jquery-ujs remote form submission is incompatible with the refile gem. See refile issue 58: https://github.com/refile/refile/issues/58

This pull request fixes that issue by adding a name attribute requirement to the `fileInputSelector`. 

The refile gem triggers upload of files as soon as they are selected by the user (prior to form submission). The upload is done asynchronously and directly to the file storage provider (generally S3). When the file upload is completed, a token value is stored in a hidden field, and the name attribute of the file input is removed, to prevent submission of that field to the backend server. 

Thus filtering file inputs without a name attribute in jquery-ujs would mimic the existing behavior of web browsers and remove the behavior that currently causes refile to fail when used in combination with remote-form submission via jquery-ujs.

Note: jquery-ujs already uses a name attribute to filter required field inputs
See: https://github.com/rails/jquery-ujs/blob/72ca4f1a4ea205f94cf6c42c1bf7f0b90c429858/src/rails.js#L48
