### PR TITLE
Allow manual initialization of jQuery UJS, if jQuery is not exposed to global namespace

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -1,4 +1,4 @@
-(function($, undefined) {
+/* jshint node: true */
 
 /**
  * Unobtrusive scripting adapter for jQuery
@@ -10,10 +10,13 @@
  *
  */
 
-  // Cut down on the number of issues from people inadvertently including jquery_ujs twice
-  // by detecting and raising an error when it happens.
+(function() {
   'use strict';
 
+  var jqueryUjsInit = function($, undefined) {
+
+  // Cut down on the number of issues from people inadvertently including jquery_ujs twice
+  // by detecting and raising an error when it happens.
   if ( $.rails !== undefined ) {
     $.error('jquery-ujs has already been loaded!');
   }
@@ -552,4 +555,11 @@
     });
   }
 
-})( jQuery );
+  };
+
+  if (window.jQuery) {
+    jqueryUjsInit(jQuery);
+  } else if (typeof exports === 'object' && typeof module === 'object') {
+    module.exports = jqueryUjsInit;
+  }
+})();


### PR DESCRIPTION
**Problem**

When you are using jQuery as a common js module, you try not to export it to window and require it manually only when you need it. But current implementation of jquery-ujs expects that jQuery is accessible in a global namespace.

**Solution**

This simple fix just exports initialization function as a module, if there is no `window.jQuery`.
In this case you can use it like that:

```coffee
$ = require 'jquery'
jqueryUjsInit = require 'jquery-ujs'

jqueryUjsInit($)
```

If there is a global jQuery, then requiring `jquery-ujs` will be just enough:

```coffee
require 'jquery-ujs'
```

So, this change should be completely backward compatible. Just let me know, if I need to add tests here, or suggest your concerns, I'd be really glad to help pushing this fix forward.

**upd:** I tried to use original indentation, so it will be easier to inspect the diff.