### PR TITLE
Update README.md application.js instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Require both `jquery` and `jquery-ujs` into your application.js manifest.
 
 ```javascript
 //= require jquery
-//= require jquery-ujs
+//= require jquery_ujs
 ```
 
 How to run tests


### PR DESCRIPTION
Usage instructions in the application.js used a hyphen instead of underscore.