### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Run `bower install jquery-ujs --save` to install the jquery-ujs package.
 Usage
 ------------
 
-Require both `jquery` and `jquery-ujs` into your application.js manifest.
+Require both `jquery` and `jquery_ujs` into your application.js manifest.
 
 ```javascript
 //= require jquery
-//= require jquery-ujs
+//= require jquery_ujs
 ```
 
 How to run tests


### PR DESCRIPTION
I noticed the conflicting info on the readme and was able to validate that the proper file/library to require within a manifest is `jquery_ujs` instead of `jquery-ujs`.