### PR TITLE
Change jquery dependency to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/rails/jquery-ujs/issues"
   },
   "homepage": "https://github.com/rails/jquery-ujs#readme",
-  "dependencies": {
+  "peerDependencies": {
     "jquery": ">=1.8.0"
   }
 }


### PR DESCRIPTION
Having jquery as a dependency causes yarn to install multiple copies of jquery under certain conditions and can break functionality. See https://github.com/yarnpkg/yarn/issues/5561#issuecomment-375657432 Having a [peerDependency](https://yarnpkg.com/lang/en/docs/dependency-types/#toc-peerdependencies) should ensure only one copy of jquery is installed by yarn.