### PR TITLE
Submit empty value for unchecked radio/checkbox input.

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -131,6 +131,9 @@
           method = element.data('method');
           url = element.data('url');
           data = element.serialize();
+          if (element.is('input[type=checkbox],input[type=radio]')) {
+            data = element.attr('name') + '=0&' + data;
+          }
           if (element.data('params')) data = data + '&' + element.data('params');
         } else if (element.is(rails.buttonClickSelector)) {
           method = element.data('method') || 'get';

--- a/test/public/test/data-remote.js
+++ b/test/public/test/data-remote.js
@@ -143,6 +143,34 @@ asyncTest('changing a select option with data-remote attribute', 5, function() {
     .trigger('change');
 });
 
+asyncTest('submitting an unchecked checkbox with data-remote attribute submits input with value 0', 3, function () {
+  $('#qunit-fixture')
+    .append($('<input type="checkbox" name="user[active]" value="1" data-remote="true" data-url="/echo">'));
+
+  $('input[type="checkbox"][data-remote]')
+    .on('ajax:success', function (e, data, status, xhr) {
+      App.assertCallbackInvoked('ajax:success');
+      App.assertRequestPath(data, '/echo');
+      equal(data.params.user.active, '0', 'ajax arguments should have key active with value 0');
+    })
+    .on('ajax:complete', function () { start() })
+    .trigger('change');
+})
+
+asyncTest('submitting an unchecked radio button with data-remote attribute submits input with value 0', 3, function () {
+  $('#qunit-fixture')
+    .append($('<input type="radio" name="user[active]" value="1" data-remote="true" data-url="/echo">'));
+
+  $('input[type="radio"][data-remote]')
+    .on('ajax:success', function (e, data, status, xhr) {
+      App.assertCallbackInvoked('ajax:success');
+      App.assertRequestPath(data, '/echo');
+      equal(data.params.user.active, '0', 'ajax arguments should have key active with value 0');
+    })
+    .on('ajax:complete', function () { start() })
+    .trigger('change');
+})
+
 asyncTest('submitting form with data-remote attribute', 4, function() {
   $('form[data-remote]')
     .on('ajax:success', function(e, data, status, xhr) {


### PR DESCRIPTION
This pull fixes an issue with having `data-remote=true` on a radio or checkbox input. Because the browser will not send a value for an unchecked input this PR adds the empty value. Just like the regular Rails form would.

fixes #440 