### PR TITLE
Don't attach UJS form submission handlers to Turbo forms

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -36,10 +36,10 @@
     inputChangeSelector: 'select[data-remote], input[data-remote], textarea[data-remote]',
 
     // Form elements bound by jquery-ujs
-    formSubmitSelector: 'form',
+    formSubmitSelector: 'form:not([data-turbo=true])',
 
     // Form input elements bound by jquery-ujs
-    formInputClickSelector: 'form input[type=submit], form input[type=image], form button[type=submit], form button:not([type]), input[type=submit][form], input[type=image][form], button[type=submit][form], button[form]:not([type])',
+    formInputClickSelector: 'form:not([data-turbo=true]) input[type=submit], form:not([data-turbo=true]) input[type=image], form:not([data-turbo=true]) button[type=submit], form:not([data-turbo=true]) button:not([type]), input[type=submit][form], input[type=image][form], button[type=submit][form], button[form]:not([type])',
 
     // Form input elements disabled during form submission
     disableSelector: 'input[data-disable-with]:enabled, button[data-disable-with]:enabled, textarea[data-disable-with]:enabled, input[data-disable]:enabled, button[data-disable]:enabled, textarea[data-disable]:enabled',


### PR DESCRIPTION
If you're migrating an application written for Rails UJS to the new Turbo framework in Hotwire, you might well want to have Turbo and UJS coexisting during the migration (or forever!). To do this, you need a way to distinguish how handles form submissions. With these updated selectors, Rails UJS will leave forms marked with data-turbo=true alone, leaving them to be processed by Turbo.

(Mirror PR of https://github.com/rails/rails/pull/42476).